### PR TITLE
NEW: @W-15652762@: Add configuration parsing and validation abilities

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -18,7 +18,10 @@ jobs:
               exit 1
           fi
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -659,9 +659,8 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.2.4.tgz",
-      "integrity": "sha512-Ttl/jHpxfS3st5sxwICYfk4pOH0WrLI1SpW283GgQL7sCWU7EHIOhX4b4fkIxr3tkfzwg8+FNojtzsIEE7Ecgg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -1233,6 +1232,10 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -4703,7 +4706,9 @@
       "license": "BSD-3-Clause license",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.1.1",
-        "@types/node": "^20.0.0"
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.0.0",
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
@@ -4717,6 +4722,20 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/code-analyzer-core/node_modules/argparse": {
+      "version": "2.0.1",
+      "license": "Python-2.0"
+    },
+    "packages/code-analyzer-core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "packages/code-analyzer-engine-api": {
@@ -4742,9 +4761,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/@eslint/eslintrc": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.0.2.tgz",
-      "integrity": "sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -4765,9 +4783,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -4779,15 +4796,13 @@
     },
     "packages/code-analyzer-engine-api/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "packages/code-analyzer-engine-api/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4797,9 +4812,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/eslint": {
       "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.2.0.tgz",
-      "integrity": "sha512-0n/I88vZpCOzO+PQpt0lbsqmn9AsnsJAQseIqhZFI8ibQT0U1AkEKRxA3EVMos0BoHSXDQvCXY25TUjB5tr8Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4848,9 +4862,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/eslint-scope": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.1.tgz",
-      "integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -4864,9 +4877,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/eslint-visitor-keys": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4876,9 +4888,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/espree": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.11.3",
         "acorn-jsx": "^5.3.2",
@@ -4893,9 +4904,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -4905,9 +4915,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -4921,9 +4930,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -4934,9 +4942,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4946,9 +4953,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4958,9 +4964,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -4973,9 +4978,8 @@
     },
     "packages/code-analyzer-engine-api/node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "package": "npm run package --workspaces --if-present",
     "all": "npm run build && npm run test && npm run lint && npm run package",
     "clean": "npm run clean --workspaces",
-    "postclean": "rimraf coverage"
+    "postclean": "rimraf coverage",
+    "showcoverage": "open ./coverage/lcov-report/index.html"
   },
   "devDependencies": {
     "jest": "^29.0.0",
@@ -19,8 +20,6 @@
     "rimraf": "*"
   },
   "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node",
     "coverageThreshold":  {
       "global": {
         "branches": 80,
@@ -29,15 +28,12 @@
         "statements": 80
       }
     },
-    "testMatch": [
-      "**/*.test.ts"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/"
+    "projects": [
+      "<rootDir>/packages/*"
     ],
     "collectCoverageFrom": [
-      "packages/**/src/**/*.ts",
-      "!packages/**/src/index.ts"
+      "src/**/*.ts",
+      "!src/index.ts"
     ]
   }
 }

--- a/packages/code-analyzer-core/package.json
+++ b/packages/code-analyzer-core/package.json
@@ -14,7 +14,9 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@salesforce/code-analyzer-engine-api": "0.1.1",
-    "@types/node": "^20.0.0"
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.0.0",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.2.0",
@@ -41,7 +43,8 @@
     "package": "npm pack",
     "all": "npm run build && npm run test && npm run lint && npm run package",
     "clean": "tsc --build tsconfig.build.json --clean",
-    "postclean": "rimraf dist && rimraf coverage && rimraf ./*.tgz"
+    "postclean": "rimraf dist && rimraf coverage && rimraf ./*.tgz",
+    "showcoverage": "open ./coverage/lcov-report/index.html"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -4,25 +4,11 @@ import {Event, EventType, LogLevel} from "./events"
 import {getMessage} from "./messages";
 import * as engApi from "@salesforce/code-analyzer-engine-api"
 import {EventEmitter} from "node:events";
+import {CodeAnalyzerConfig} from "./config";
 
 export type RunOptions = {
     filesToInclude: string[]
     entryPoints?: string[]
-}
-
-// Currently we have no configuration abilities implemented. So this is just a placeholder for now.
-export class CodeAnalyzerConfig {
-    public static withDefaults() {
-        return new CodeAnalyzerConfig();
-    }
-
-    private constructor() {
-    }
-
-    public getEngineSpecificConfig(_engineName: string): engApi.ConfigObject {
-        // To be implemented soon
-        return {}
-    }
 }
 
 export class CodeAnalyzer {
@@ -42,7 +28,7 @@ export class CodeAnalyzer {
         const enginePluginV1: engApi.EnginePluginV1 = enginePlugin as engApi.EnginePluginV1;
 
         for (const engineName of getAvailableEngineNamesFromPlugin(enginePluginV1)) {
-            const engConf: engApi.ConfigObject = this.config.getEngineSpecificConfig(engineName);
+            const engConf: engApi.ConfigObject = this.config.getEngineSettingsFor(engineName);
             const engine: engApi.Engine = createEngineFromPlugin(enginePluginV1, engineName, engConf);
             this.addEngineIfValid(engineName, engine);
         }

--- a/packages/code-analyzer-core/src/config.ts
+++ b/packages/code-analyzer-core/src/config.ts
@@ -1,0 +1,181 @@
+import * as engApi from "@salesforce/code-analyzer-engine-api";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from "node:os";
+import * as yaml from 'js-yaml';
+import {getMessage} from "./messages";
+import {SeverityLevel} from "./rules";
+
+export type EngineRuleSettings = {
+    severity?: SeverityLevel
+    tags?: string[]
+}
+
+type TopLevelConfig = {
+    log_folder: string
+    rule_settings: Record<string, Record<string,EngineRuleSettings>>
+    engine_settings: Record<string, engApi.ConfigObject>
+}
+
+const DEFAULT_CONFIG: TopLevelConfig = {
+    log_folder: os.tmpdir(),
+    rule_settings: {},
+    engine_settings: {}
+};
+
+export class CodeAnalyzerConfig {
+    private readonly config: TopLevelConfig;
+
+    public static withDefaults() {
+        return new CodeAnalyzerConfig(DEFAULT_CONFIG);
+    }
+
+    public static fromFile(file: string) {
+        file = toAbsolutePath(file);
+        if (!fs.existsSync(file)) {
+            throw new Error(getMessage('ConfigFileDoesNotExist', file));
+        }
+        const fileContents: string = fs.readFileSync(file, 'utf8');
+
+        const fileExt : string = file.split('.').pop()?.toLowerCase() || "";
+
+        if (fileExt == 'json') {
+            return CodeAnalyzerConfig.fromJsonString(fileContents);
+        }  else if (fileExt == 'yaml' || fileExt == 'yml') {
+            return CodeAnalyzerConfig.fromYamlString(fileContents);
+        } else {
+            throw new Error(getMessage('ConfigFileExtensionUnsupported', file, 'json,yaml,yml'))
+        }
+    }
+
+    public static fromJsonString(jsonString: string): CodeAnalyzerConfig {
+        const data: object = parseAndValidate(() => JSON.parse(jsonString));
+        return CodeAnalyzerConfig.fromObject(data);
+    }
+
+    public static fromYamlString(yamlString: string): CodeAnalyzerConfig {
+        const data: object = parseAndValidate(() => yaml.load(yamlString));
+        return CodeAnalyzerConfig.fromObject(data);
+    }
+
+    public static fromObject(data: object): CodeAnalyzerConfig {
+        const config: TopLevelConfig = {
+            log_folder: validateAndExtractLogFolderValue(data),
+            rule_settings: validateAndExtractRuleSettingsValue(data),
+            engine_settings: validateAndExtractEngineSettingsValue(data)
+        }
+        return new CodeAnalyzerConfig(config);
+    }
+
+    private constructor(config: TopLevelConfig) {
+        this.config = config;
+    }
+
+    public getLogFolder(): string {
+        return this.config.log_folder;
+    }
+
+    public getRuleSettingsFor(engineName: string): EngineRuleSettings {
+        return this.config.rule_settings[engineName] || {};
+    }
+
+    public getEngineSettingsFor(engineName: string): engApi.ConfigObject {
+        return this.config.engine_settings[engineName] || {};
+    }
+}
+
+function validateAndExtractLogFolderValue(data: object): string {
+    if (!('log_folder' in data)) {
+        return DEFAULT_CONFIG.log_folder;
+    }
+    const logFolder: string = toAbsolutePath(validateType('string', data['log_folder'], 'log_folder'));
+    if (!fs.existsSync(logFolder)) {
+        throw new Error(getMessage('ConfigValueFolderMustExist', 'log_folder', logFolder));
+    } else if (!fs.statSync(logFolder).isDirectory()) {
+        throw new Error(getMessage('ConfigValueMustBeFolder', 'log_folder', logFolder));
+    }
+    return logFolder;
+}
+
+function validateAndExtractRuleSettingsValue(data: object): Record<string, Record<string, EngineRuleSettings>> {
+    if (!('rule_settings' in data)) {
+        return DEFAULT_CONFIG.rule_settings;
+    }
+    const ruleSettingsObj: object = validateObject(data['rule_settings'], 'rule_settings');
+    for (const [engineName, ruleSettingsForEngine] of Object.entries(ruleSettingsObj)) {
+        const ruleSettingsForEngineObj: object = validateObject(ruleSettingsForEngine, `rule_settings.${engineName}`);
+        for (const [ruleName, engineRuleSettings] of Object.entries(ruleSettingsForEngineObj)) {
+            validateEngineRuleSettings(engineRuleSettings, `rule_settings.${engineName}.${ruleName}`);
+        }
+    }
+    return data['rule_settings'] as Record<string, Record<string, EngineRuleSettings>>;
+}
+
+function validateEngineRuleSettings(value: unknown, valueKey: string): void {
+    const valueObj: object = validateObject(value, valueKey);
+    if ('severity' in valueObj) {
+        validateSeverityValue(valueObj['severity'], `${valueKey}.severity`);
+    }
+    if ('tags' in valueObj ) {
+        validateTagsValue(valueObj['tags'], `${valueKey}.tags`);
+    }
+}
+
+function validateObject(value: unknown, valueKey: string) {
+    return validateType<object>('object', value, valueKey);
+}
+
+function validateType<T>(expectedType: string, value: unknown, valueKey: string): T {
+    if (typeOf(value) !== expectedType) {
+        throw new Error(getMessage('ConfigValueMustBeOfType', valueKey, expectedType, typeOf(value)));
+    }
+    return value as T;
+}
+
+function validateSeverityValue(value: unknown, valueKey: string): void {
+    // Note that Object.values(SeverityLevel) returns [1,2,3,4,5,"Critical","High","Moderate","Low","Info"]
+    if ((typeof value !== 'string' && typeof value !== 'number')
+        || !Object.values(SeverityLevel).includes(value as string | number)) {
+        throw new Error(getMessage('ConfigValueNotAValidSeverityLevel', valueKey,
+            JSON.stringify(Object.values(SeverityLevel)), JSON.stringify(value)));
+    }
+}
+
+function validateTagsValue(value: unknown, valueKey: string): void {
+    if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+        throw new Error(getMessage('ConfigValueNotAValidTagsLevel', valueKey, JSON.stringify(value)));
+    }
+}
+
+function validateAndExtractEngineSettingsValue(data: object): Record<string, engApi.ConfigObject> {
+    if (!('engine_settings' in data)) {
+        return DEFAULT_CONFIG.engine_settings;
+    }
+    const engineSettingsObj: object = validateObject(data['engine_settings'], 'engine_settings');
+    for (const [engineName, settingsForEngine] of Object.entries(engineSettingsObj)) {
+        validateObject(settingsForEngine, `engine_settings.${engineName}`);
+    }
+    return engineSettingsObj as Record<string, engApi.ConfigObject>;
+}
+
+function parseAndValidate(parseFcn: () => unknown): object {
+    let data;
+    try {
+        data = parseFcn();
+    } catch (err) {
+        throw new Error(getMessage('ConfigContentFailedToParse', (err as Error).message), { cause: err });
+    }
+    if (typeOf(data) !== 'object') {
+        throw new Error(getMessage('ConfigContentNotAnObject', typeOf(data)));
+    }
+    return data as object;
+}
+
+function toAbsolutePath(fileOrFolder: string): string {
+    // Convert slashes to platform specific slashes and then convert to absolute path
+    return path.resolve(fileOrFolder.replace(/[\\/]/g, path.sep));
+}
+
+function typeOf(value: unknown) {
+    return value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
+}

--- a/packages/code-analyzer-core/src/config.ts
+++ b/packages/code-analyzer-core/src/config.ts
@@ -8,8 +8,8 @@ import {SeverityLevel} from "./rules";
 
 const FIELDS = {
     LOG_FOLDER: 'log_folder',
-    RULE_SETTINGS: 'rule_settings',
-    ENGINE_SETTINGS: 'engine_settings',
+    RULES: 'rules',
+    ENGINES: 'engines',
     SEVERITY: 'severity',
     TAGS: 'tags'
 } as const
@@ -21,14 +21,14 @@ export type EngineRuleSettings = {
 
 type TopLevelConfig = {
     log_folder: string
-    rule_settings: Record<string, Record<string,EngineRuleSettings>>
-    engine_settings: Record<string, engApi.ConfigObject>
+    rules: Record<string, Record<string,EngineRuleSettings>>
+    engines: Record<string, engApi.ConfigObject>
 }
 
 const DEFAULT_CONFIG: TopLevelConfig = {
     log_folder: os.tmpdir(),
-    rule_settings: {},
-    engine_settings: {}
+    rules: {},
+    engines: {}
 };
 
 export class CodeAnalyzerConfig {
@@ -69,8 +69,8 @@ export class CodeAnalyzerConfig {
     public static fromObject(data: object): CodeAnalyzerConfig {
         const config: TopLevelConfig = {
             log_folder: validateAndExtractLogFolderValue(data),
-            rule_settings: validateAndExtractRuleSettingsValue(data),
-            engine_settings: validateAndExtractEngineSettingsValue(data)
+            rules: validateAndExtractRuleSettingsValue(data),
+            engines: validateAndExtractEngineSettingsValue(data)
         }
         return new CodeAnalyzerConfig(config);
     }
@@ -84,11 +84,11 @@ export class CodeAnalyzerConfig {
     }
 
     public getRuleSettingsFor(engineName: string): EngineRuleSettings {
-        return this.config.rule_settings[engineName] || {};
+        return this.config.rules[engineName] || {};
     }
 
     public getEngineSettingsFor(engineName: string): engApi.ConfigObject {
-        return this.config.engine_settings[engineName] || {};
+        return this.config.engines[engineName] || {};
     }
 }
 
@@ -106,17 +106,17 @@ function validateAndExtractLogFolderValue(data: object): string {
 }
 
 function validateAndExtractRuleSettingsValue(data: object): Record<string, Record<string, EngineRuleSettings>> {
-    if (!(FIELDS.RULE_SETTINGS in data)) {
-        return DEFAULT_CONFIG.rule_settings;
+    if (!(FIELDS.RULES in data)) {
+        return DEFAULT_CONFIG.rules;
     }
-    const ruleSettingsObj: object = validateObject(data[FIELDS.RULE_SETTINGS], FIELDS.RULE_SETTINGS);
+    const ruleSettingsObj: object = validateObject(data[FIELDS.RULES], FIELDS.RULES);
     for (const [engineName, ruleSettingsForEngine] of Object.entries(ruleSettingsObj)) {
-        const ruleSettingsForEngineObj: object = validateObject(ruleSettingsForEngine, `${FIELDS.RULE_SETTINGS}.${engineName}`);
+        const ruleSettingsForEngineObj: object = validateObject(ruleSettingsForEngine, `${FIELDS.RULES}.${engineName}`);
         for (const [ruleName, engineRuleSettings] of Object.entries(ruleSettingsForEngineObj)) {
-            validateEngineRuleSettings(engineRuleSettings, `${FIELDS.RULE_SETTINGS}.${engineName}.${ruleName}`);
+            validateEngineRuleSettings(engineRuleSettings, `${FIELDS.RULES}.${engineName}.${ruleName}`);
         }
     }
-    return data[FIELDS.RULE_SETTINGS] as Record<string, Record<string, EngineRuleSettings>>;
+    return data[FIELDS.RULES] as Record<string, Record<string, EngineRuleSettings>>;
 }
 
 function validateEngineRuleSettings(value: unknown, valueKey: string): void {
@@ -156,12 +156,12 @@ function validateTagsValue(value: unknown, valueKey: string): void {
 }
 
 function validateAndExtractEngineSettingsValue(data: object): Record<string, engApi.ConfigObject> {
-    if (!(FIELDS.ENGINE_SETTINGS in data)) {
-        return DEFAULT_CONFIG.engine_settings;
+    if (!(FIELDS.ENGINES in data)) {
+        return DEFAULT_CONFIG.engines;
     }
-    const engineSettingsObj: object = validateObject(data[FIELDS.ENGINE_SETTINGS], FIELDS.ENGINE_SETTINGS);
+    const engineSettingsObj: object = validateObject(data[FIELDS.ENGINES], FIELDS.ENGINES);
     for (const [engineName, settingsForEngine] of Object.entries(engineSettingsObj)) {
-        validateObject(settingsForEngine, `${FIELDS.ENGINE_SETTINGS}.${engineName}`);
+        validateObject(settingsForEngine, `${FIELDS.ENGINES}.${engineName}`);
     }
     return engineSettingsObj as Record<string, engApi.ConfigObject>;
 }

--- a/packages/code-analyzer-core/src/index.ts
+++ b/packages/code-analyzer-core/src/index.ts
@@ -1,6 +1,9 @@
 export {
+    CodeAnalyzerConfig
+} from "./config"
+
+export {
     CodeAnalyzer,
-    CodeAnalyzerConfig,
     RunOptions
 } from "./code-analyzer"
 

--- a/packages/code-analyzer-core/src/messages.ts
+++ b/packages/code-analyzer-core/src/messages.ts
@@ -20,7 +20,34 @@ const messageCatalog : { [key: string]: string } = {
         `Failed to create engine with name "%s" since the plugin's createEngine method through an error:\n%s`,
 
     EngineAdded:
-        'Engine with name "%s" was added to Code Analyzer.'
+        'Engine with name "%s" was added to Code Analyzer.',
+
+    ConfigFileDoesNotExist:
+        'The specified configuration file "%s" does not exist.',
+
+    ConfigFileExtensionUnsupported:
+        'The specified configuration file "%s" has an unsupported file extension. Supported extensions are: %s',
+
+    ConfigContentFailedToParse:
+        'Failed to parse the configuration content. Error:\n%s',
+
+    ConfigContentNotAnObject:
+        'The configuration content is invalid since it is of type %s instead of type object.',
+
+    ConfigValueMustBeOfType:
+        'The %s configuration value must be of type %s instead of type %s.',
+
+    ConfigValueNotAValidSeverityLevel:
+        'The %s configuration value must be one of the following: %s. Instead received: %s',
+
+    ConfigValueNotAValidTagsLevel:
+        'The %s configuration value must an array of strings. Instead received: %s',
+
+    ConfigValueFolderMustExist:
+        'The folder specified by the %s configuration value does not exist: %s',
+
+    ConfigValueMustBeFolder:
+        'The %s configuration value is not a folder: %s'
 }
 
 /**

--- a/packages/code-analyzer-core/test/config.test.ts
+++ b/packages/code-analyzer-core/test/config.test.ts
@@ -118,55 +118,55 @@ describe("Tests for creating and accessing configuration values", () => {
             getMessage('ConfigContentNotAnObject','null'));
     });
 
-    it("When engine_settings is not an object then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({engine_settings: ['oops']})).toThrow(
-            getMessage('ConfigValueMustBeOfType','engine_settings', 'object', 'array'));
+    it("When engines value is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({engines: ['oops']})).toThrow(
+            getMessage('ConfigValueMustBeOfType','engines', 'object', 'array'));
     });
 
-    it("When engine_settings.someEngine is not an object then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({engine_settings: {someEngine: 3.2}})).toThrow(
-            getMessage('ConfigValueMustBeOfType','engine_settings.someEngine', 'object', 'number'));
+    it("When engines.someEngine is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({engines: {someEngine: 3.2}})).toThrow(
+            getMessage('ConfigValueMustBeOfType','engines.someEngine', 'object', 'number'));
     });
 
-    it("When rule_settings is not an object then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: 3})).toThrow(
-            getMessage('ConfigValueMustBeOfType','rule_settings', 'object', 'number'));
+    it("When rules is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rules: 3})).toThrow(
+            getMessage('ConfigValueMustBeOfType','rules', 'object', 'number'));
     });
 
-    it("When rule_settings.someEngine is not an object then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: null}})).toThrow(
-            getMessage('ConfigValueMustBeOfType','rule_settings.someEngine', 'object', 'null'));
+    it("When rules.someEngine is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: null}})).toThrow(
+            getMessage('ConfigValueMustBeOfType','rules.someEngine', 'object', 'null'));
     });
 
-    it("When rule_settings.someEngine.someRule is not an object then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {someRule: [1,2]}}})).toThrow(
-            getMessage('ConfigValueMustBeOfType','rule_settings.someEngine.someRule', 'object', 'array'));
+    it("When rules.someEngine.someRule is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {someRule: [1,2]}}})).toThrow(
+            getMessage('ConfigValueMustBeOfType','rules.someEngine.someRule', 'object', 'array'));
     });
 
     it("When the severity of a rule not a valid value then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {
             goodSevRule1: {severity: 3},
             goodSevRule2: {severity: "High"},
             badSevRule: {severity: 0}
         }}})).toThrow(
-            getMessage('ConfigValueNotAValidSeverityLevel','rule_settings.someEngine.badSevRule.severity',
+            getMessage('ConfigValueNotAValidSeverityLevel','rules.someEngine.badSevRule.severity',
                 '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', '0'));
 
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {badSevRule: {severity: "oops"}}}})).toThrow(
-            getMessage('ConfigValueNotAValidSeverityLevel','rule_settings.someEngine.badSevRule.severity',
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {badSevRule: {severity: "oops"}}}})).toThrow(
+            getMessage('ConfigValueNotAValidSeverityLevel','rules.someEngine.badSevRule.severity',
                 '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', '"oops"'));
     });
 
     it("When the tags of a rule is not a string array then we throw an error", () => {
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {
                     goodTagsRule1: {tags: ['default']},
                     badTagsRule: {tags: 'oops'},
                     goodTagsRule2: {tags: ['helloWorld', 'great']}
                 }}})).toThrow(
-            getMessage('ConfigValueNotAValidTagsLevel','rule_settings.someEngine.badTagsRule.tags', '"oops"'));
+            getMessage('ConfigValueNotAValidTagsLevel','rules.someEngine.badTagsRule.tags', '"oops"'));
 
-        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {badTagsRule: {tags: null},}}})).toThrow(
-            getMessage('ConfigValueNotAValidTagsLevel','rule_settings.someEngine.badTagsRule.tags', 'null'));
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {badTagsRule: {tags: null},}}})).toThrow(
+            getMessage('ConfigValueNotAValidTagsLevel','rules.someEngine.badTagsRule.tags', 'null'));
     });
 
     it("When tags is an empty array, then use the empty array as provided", () => {
@@ -174,7 +174,7 @@ describe("Tests for creating and accessing configuration values", () => {
             someRule1: {tags: []}, // Should be accepted
             someRule2: {severity: 4, tags: ['Performance']}
         };
-        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: someEngineRuleSettings}});
+        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.fromObject({rules: {someEngine: someEngineRuleSettings}});
         expect(conf.getRuleSettingsFor('someEngine')).toEqual(someEngineRuleSettings);
     });
 

--- a/packages/code-analyzer-core/test/config.test.ts
+++ b/packages/code-analyzer-core/test/config.test.ts
@@ -1,0 +1,194 @@
+import {CodeAnalyzerConfig, SeverityLevel} from "../src";
+import * as os from "node:os";
+import * as path from "node:path";
+import {getMessage} from "../src/messages";
+import {changeWorkingDirectoryToPackageRoot} from "./test-helpers";
+
+describe("Tests for creating and accessing configuration values", () => {
+    changeWorkingDirectoryToPackageRoot();
+
+    it("When constructing config withDefaults then default values are returned", () => {
+        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.withDefaults();
+
+        expect(conf.getLogFolder()).toEqual(os.tmpdir());
+        expect(conf.getRuleSettingsFor("stubEngine1")).toEqual({});
+        expect(conf.getEngineSettingsFor("stubEngine1")).toEqual({});
+        expect(conf.getRuleSettingsFor("stubEngine2")).toEqual({});
+        expect(conf.getEngineSettingsFor("stubEngine2")).toEqual({});
+    });
+
+    it("When configuration file does not exist, then throw an error", () => {
+        const nonExistingFile: string = path.resolve(__dirname, "doesNotExist");
+        expect(() => CodeAnalyzerConfig.fromFile(nonExistingFile)).toThrow(
+            getMessage('ConfigFileDoesNotExist', nonExistingFile));
+    });
+
+    it("When configuration file has unsupported extension, then throw an error", () => {
+        const fileWithBadExtension: string = path.resolve(__dirname, "config.test.ts");
+        expect(() => CodeAnalyzerConfig.fromFile(fileWithBadExtension)).toThrow(
+            getMessage('ConfigFileExtensionUnsupported', fileWithBadExtension, 'json,yaml,yml'));
+        const fileWithNoExtension: string = path.resolve(__dirname, "..", "LICENSE");
+        expect(() => CodeAnalyzerConfig.fromFile(fileWithNoExtension)).toThrow(
+            getMessage('ConfigFileExtensionUnsupported', fileWithNoExtension, 'json,yaml,yml'));
+    });
+
+    it("When constructing config from yaml file then values from file are parsed correctly", () => {
+        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.fromFile(path.resolve(__dirname, 'test-data', 'sample-config-01.yaml'));
+        expect(conf.getLogFolder()).toEqual(path.resolve(__dirname, 'test-data', 'sampleLogFolder'));
+        expect(conf.getRuleSettingsFor('stubEngine1')).toEqual({
+            stub1RuleB: {
+                severity: SeverityLevel.Critical
+            },
+            stub1RuleD: {
+                severity: SeverityLevel.Info,
+                tags: ['default', 'CodeStyle']
+            }
+        });
+        expect(conf.getRuleSettingsFor('stubEngine2')).toEqual({
+            stub2RuleA: {
+                tags: ['Security']
+            }
+        });
+        expect(conf.getEngineSettingsFor('stubEngine1')).toEqual({});
+        expect(conf.getEngineSettingsFor('stubEngine2')).toEqual({});
+    });
+
+    it("When constructing config from file with yml extension then it is parsed as a yaml file", () => {
+        // Also note that Yml should work just like yml. Case doesn't matter.
+        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.fromFile(path.resolve(__dirname, 'test-data', 'sample-config-02.Yml'));
+        expect(conf.getLogFolder()).toEqual(os.tmpdir());
+        expect(conf.getRuleSettingsFor('stubEngine1')).toEqual({});
+        expect(conf.getRuleSettingsFor('stubEngine2')).toEqual({
+            stub2RuleC: {
+                severity: SeverityLevel.Moderate
+            }
+        });
+        expect(conf.getEngineSettingsFor('stubEngine1')).toEqual({
+            miscSetting1: true,
+            miscSetting2: {
+                miscSetting2A: 3,
+                miscSetting2B: ["hello", "world"]
+            }
+        });
+        expect(conf.getEngineSettingsFor('stubEngine2')).toEqual({});
+    });
+
+    it("When constructing config from json file then values from file are parsed correctly", () => {
+        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.fromFile(path.resolve(__dirname, 'test-data', 'sample-config-03.json'));
+        expect(conf.getLogFolder()).toEqual(path.resolve(__dirname, 'test-data', 'sampleLogFolder'));
+        expect(conf.getRuleSettingsFor('stubEngine1')).toEqual({});
+        expect(conf.getRuleSettingsFor('stubEngine2')).toEqual({});
+        expect(conf.getEngineSettingsFor('stubEngine1')).toEqual({});
+        expect(conf.getEngineSettingsFor('stubEngine2')).toEqual({miscSetting: "miscValue"});
+    });
+
+    it("When constructing config from invalid yaml string then we throw an error", () => {
+        try {
+            CodeAnalyzerConfig.fromYamlString('oops: this: should error');
+            fail('Expected an exception to be thrown.')
+        } catch (err) {
+            const errMsg: string = (err as Error).message;
+            expect(errMsg).toContain(getMessage('ConfigContentFailedToParse',''));
+            expect(errMsg).toContain('bad indentation of a mapping entry');
+        }
+    });
+
+    it("When constructing config from invalid json string then we throw an error", () => {
+        try {
+            CodeAnalyzerConfig.fromJsonString('this.Is{NotValidJson');
+            fail('Expected an exception to be thrown.')
+        } catch (err) {
+            const errMsg: string = (err as Error).message;
+            expect(errMsg).toContain(getMessage('ConfigContentFailedToParse',''));
+            expect(errMsg).toContain('Unexpected token');
+        }
+    });
+
+    it("When constructing config from yaml string that isn't an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromYamlString("3")).toThrow(
+            getMessage('ConfigContentNotAnObject','number'));
+        expect(() => CodeAnalyzerConfig.fromYamlString("null")).toThrow(
+            getMessage('ConfigContentNotAnObject','null'));
+    });
+
+    it("When constructing config from json string that isn't an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromJsonString("3")).toThrow(
+            getMessage('ConfigContentNotAnObject','number'));
+        expect(() => CodeAnalyzerConfig.fromJsonString("null")).toThrow(
+            getMessage('ConfigContentNotAnObject','null'));
+    });
+
+    it("When engine_settings is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({engine_settings: ['oops']})).toThrow(
+            getMessage('ConfigValueMustBeOfType','engine_settings', 'object', 'array'));
+    });
+
+    it("When engine_settings.someEngine is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({engine_settings: {someEngine: 3.2}})).toThrow(
+            getMessage('ConfigValueMustBeOfType','engine_settings.someEngine', 'object', 'number'));
+    });
+
+    it("When rule_settings is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: 3})).toThrow(
+            getMessage('ConfigValueMustBeOfType','rule_settings', 'object', 'number'));
+    });
+
+    it("When rule_settings.someEngine is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: null}})).toThrow(
+            getMessage('ConfigValueMustBeOfType','rule_settings.someEngine', 'object', 'null'));
+    });
+
+    it("When rule_settings.someEngine.someRule is not an object then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {someRule: [1,2]}}})).toThrow(
+            getMessage('ConfigValueMustBeOfType','rule_settings.someEngine.someRule', 'object', 'array'));
+    });
+
+    it("When the severity of a rule not a valid value then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {
+            goodSevRule1: {severity: 3},
+            goodSevRule2: {severity: "High"},
+            badSevRule: {severity: 0}
+        }}})).toThrow(
+            getMessage('ConfigValueNotAValidSeverityLevel','rule_settings.someEngine.badSevRule.severity',
+                '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', '0'));
+
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {badSevRule: {severity: "oops"}}}})).toThrow(
+            getMessage('ConfigValueNotAValidSeverityLevel','rule_settings.someEngine.badSevRule.severity',
+                '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', '"oops"'));
+    });
+
+    it("When the tags of a rule is not a string array then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {
+                    goodTagsRule1: {tags: ['default']},
+                    badTagsRule: {tags: 'oops'},
+                    goodTagsRule2: {tags: ['helloWorld', 'great']}
+                }}})).toThrow(
+            getMessage('ConfigValueNotAValidTagsLevel','rule_settings.someEngine.badTagsRule.tags', '"oops"'));
+
+        expect(() => CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: {badTagsRule: {tags: null},}}})).toThrow(
+            getMessage('ConfigValueNotAValidTagsLevel','rule_settings.someEngine.badTagsRule.tags', 'null'));
+    });
+
+    it("When tags is an empty array, then use the empty array as provided", () => {
+        const someEngineRuleSettings: object = {
+            someRule1: {tags: []}, // Should be accepted
+            someRule2: {severity: 4, tags: ['Performance']}
+        };
+        const conf: CodeAnalyzerConfig = CodeAnalyzerConfig.fromObject({rule_settings: {someEngine: someEngineRuleSettings}});
+        expect(conf.getRuleSettingsFor('someEngine')).toEqual(someEngineRuleSettings);
+    });
+
+    it("When log_folder does not exist, then throw an error", () => {
+        const nonExistingFolder: string = path.resolve(__dirname, "doesNotExist");
+        expect(() => CodeAnalyzerConfig.fromObject({log_folder: nonExistingFolder})).toThrow(
+            getMessage('ConfigValueFolderMustExist', 'log_folder', nonExistingFolder)
+        );
+    });
+
+    it("When log_folder is a file and not a folder, then throw an error", () => {
+        const notAFolder: string = path.resolve(__dirname, "config.test.ts");
+        expect(() => CodeAnalyzerConfig.fromObject({log_folder: notAFolder})).toThrow(
+            getMessage('ConfigValueMustBeFolder', 'log_folder', notAFolder)
+        );
+    });
+});

--- a/packages/code-analyzer-core/test/stubs.ts
+++ b/packages/code-analyzer-core/test/stubs.ts
@@ -4,15 +4,18 @@ import * as engApi from "@salesforce/code-analyzer-engine-api"
  * StubEnginePlugin - A plugin stub with preconfigured outputs to help with testing
  */
 export class StubEnginePlugin extends engApi.EnginePluginV1 {
+    readonly callHistoryForCreateEngine: {engineName: string, config: engApi.ConfigObject}[] = [];
+
     getAvailableEngineNames(): string[] {
         return ["stubEngine1", "stubEngine2"];
     }
 
-    createEngine(engineName: string, _config: engApi.ConfigObject): engApi.Engine {
+    createEngine(engineName: string, config: engApi.ConfigObject): engApi.Engine {
+        this.callHistoryForCreateEngine.push({engineName, config});
         if (engineName == "stubEngine1") {
-            return new StubEngine1();
+            return new StubEngine1(config);
         } else if (engineName == "stubEngine2") {
-            return new StubEngine2();
+            return new StubEngine2(config);
         } else {
             throw new Error(`Unsupported engine name: ${engineName}`)
         }
@@ -23,6 +26,11 @@ export class StubEnginePlugin extends engApi.EnginePluginV1 {
  * StubEngine1 - A sample engine stub with preconfigured outputs to help with testing
  */
 class StubEngine1 extends engApi.Engine {
+    constructor(_config: engApi.ConfigObject) {
+        // Will use the config soon but not yet.
+        super();
+    }
+
     getName(): string {
         return "stubEngine1";
     }
@@ -81,6 +89,11 @@ class StubEngine1 extends engApi.Engine {
  * StubEngine2 - A sample engine stub with preconfigured outputs to help with testing
  */
 class StubEngine2 extends engApi.Engine {
+    constructor(_config: engApi.ConfigObject) {
+        // Will use the config soon but not yet.
+        super();
+    }
+
     getName(): string {
         return "stubEngine2";
     }
@@ -161,8 +174,8 @@ export class ContradictingEnginePlugin extends engApi.EnginePluginV1 {
         return ["stubEngine1"];
     }
 
-    createEngine(_engineName: string, _config: engApi.ConfigObject): engApi.Engine {
-        return new StubEngine2(); // returns "stubEngine2" from its getName method
+    createEngine(_engineName: string, config: engApi.ConfigObject): engApi.Engine {
+        return new StubEngine2(config); // returns "stubEngine1" from its getName method - thus the contradiction
     }
 }
 
@@ -175,7 +188,7 @@ export class InvalidEnginePlugin extends engApi.EnginePluginV1 {
     }
 
     createEngine(_engineName: string, _config: engApi.ConfigObject): engApi.Engine {
-        return new InvalidEngine(); // returns "stubEngine2" from its getName method
+        return new InvalidEngine();
     }
 }
 

--- a/packages/code-analyzer-core/test/test-data/sample-config-01.yaml
+++ b/packages/code-analyzer-core/test/test-data/sample-config-01.yaml
@@ -1,0 +1,13 @@
+log_folder: test\test-data\sampleLogFolder
+
+rule_settings:
+  stubEngine1:
+    stub1RuleB:
+      severity: 1
+    stub1RuleD:
+      severity: 5
+      tags: ["default", "CodeStyle"]
+
+  stubEngine2:
+    stub2RuleA:
+      tags: ["Security"]

--- a/packages/code-analyzer-core/test/test-data/sample-config-01.yaml
+++ b/packages/code-analyzer-core/test/test-data/sample-config-01.yaml
@@ -1,6 +1,6 @@
 log_folder: test\test-data\sampleLogFolder
 
-rule_settings:
+rules:
   stubEngine1:
     stub1RuleB:
       severity: 1

--- a/packages/code-analyzer-core/test/test-data/sample-config-02.Yml
+++ b/packages/code-analyzer-core/test/test-data/sample-config-02.Yml
@@ -1,0 +1,11 @@
+rule_settings:
+  stubEngine2:
+    stub2RuleC:
+      severity: 3
+
+engine_settings:
+  stubEngine1:
+    miscSetting1: true
+    miscSetting2:
+      miscSetting2A: 3
+      miscSetting2B: ["hello", "world"]

--- a/packages/code-analyzer-core/test/test-data/sample-config-02.Yml
+++ b/packages/code-analyzer-core/test/test-data/sample-config-02.Yml
@@ -1,9 +1,9 @@
-rule_settings:
+rules:
   stubEngine2:
     stub2RuleC:
       severity: 3
 
-engine_settings:
+engines:
   stubEngine1:
     miscSetting1: true
     miscSetting2:

--- a/packages/code-analyzer-core/test/test-data/sample-config-03.json
+++ b/packages/code-analyzer-core/test/test-data/sample-config-03.json
@@ -1,0 +1,8 @@
+{
+  "log_folder": "test/test-data/sampleLogFolder",
+  "engine_settings": {
+    "stubEngine2": {
+      "miscSetting": "miscValue"
+    }
+  }
+}

--- a/packages/code-analyzer-core/test/test-data/sample-config-03.json
+++ b/packages/code-analyzer-core/test/test-data/sample-config-03.json
@@ -1,6 +1,6 @@
 {
   "log_folder": "test/test-data/sampleLogFolder",
-  "engine_settings": {
+  "engines": {
     "stubEngine2": {
       "miscSetting": "miscValue"
     }

--- a/packages/code-analyzer-core/test/test-data/sampleLogFolder/placeholder.txt
+++ b/packages/code-analyzer-core/test/test-data/sampleLogFolder/placeholder.txt
@@ -1,0 +1,1 @@
+This file is just a placeholder so that we can check in the sampleLogFolder into git to be available during testing.

--- a/packages/code-analyzer-core/test/test-helpers.ts
+++ b/packages/code-analyzer-core/test/test-helpers.ts
@@ -1,0 +1,17 @@
+import process from "node:process";
+import path from "node:path";
+
+export function changeWorkingDirectoryToPackageRoot() {
+    let original_working_directory: string;
+    beforeAll(() => {
+        // The config files use relative folders assuming the test is running from the package root directory.
+        // This directory is already typically the one used, unless we run the tests from the monorepo's root directory.
+        // Note that the package root directory is used instead of the test directory since some IDEs (like IntelliJ)
+        // fail to collect code coverage correctly unless this directory is used.
+        original_working_directory = process.cwd();
+        process.chdir(path.resolve(__dirname,'..'));
+    });
+    afterAll(() => {
+        process.chdir(original_working_directory);
+    });
+}

--- a/packages/code-analyzer-engine-api/package.json
+++ b/packages/code-analyzer-engine-api/package.json
@@ -40,7 +40,8 @@
     "package": "npm pack",
     "all": "npm run build && npm run test && npm run lint && npm run package",
     "clean": "tsc --build tsconfig.build.json --clean",
-    "postclean": "rimraf dist && rimraf coverage && rimraf ./*.tgz"
+    "postclean": "rimraf dist && rimraf coverage && rimraf ./*.tgz",
+    "showcoverage": "open ./coverage/lcov-report/index.html"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
Adding in configuration parsing and validation which will allow clients to now pass in configuration data according the schema:

log_folder
- Specify a location to write log files to. If not specified, then your machine’s default temporary directory will be used.

rules.<engine_name>.<rule_name>.severity
- Specify the severity 1 (Critical), 2 (High), 3 (Moderate), 4 (Low), or 5 (Info) level as an integer that you want to set for the specified rule.

rules.<engine_name>.<rule_name>.tags
- Specify a list of tags to set for the specified rule.

engines.<engine_name>.<engine_specific_property>
- For the specified engine, you can specify any engine specific properties and values as needed.


Clients may pass in a yaml or json file, a yaml or json string, or an object.