### PR TITLE
NEW (RegexEngine): @W-16040562@: Scaffolding for new regex engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,6 +1217,10 @@
       "resolved": "packages/code-analyzer-eslint-engine",
       "link": true
     },
+    "node_modules/@salesforce/code-analyzer-regex-engine": {
+      "resolved": "packages/code-analyzer-regex-engine",
+      "link": true
+    },
     "node_modules/@salesforce/code-analyzer-retirejs-engine": {
       "resolved": "packages/code-analyzer-retirejs-engine",
       "link": true
@@ -5492,10 +5496,10 @@
     },
     "packages/code-analyzer-core": {
       "name": "@salesforce/code-analyzer-core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "BSD-3-Clause license",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.3.0",
+        "@salesforce/code-analyzer-engine-api": "0.4.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "csv-stringify": "^6.5.0",
@@ -5535,7 +5539,7 @@
     },
     "packages/code-analyzer-engine-api": {
       "name": "@salesforce/code-analyzer-engine-api",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "BSD-3-Clause license",
       "dependencies": {
         "@types/node": "^20.0.0"
@@ -5559,7 +5563,28 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause license",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.3.0",
+        "@salesforce/code-analyzer-engine-api": "0.4.0",
+        "@types/node": "^20.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^8.57.0",
+        "@types/jest": "^29.0.0",
+        "eslint": "^8.57.0",
+        "jest": "^29.0.0",
+        "rimraf": "*",
+        "ts-jest": "^29.0.0",
+        "typescript": "^5.4.5",
+        "typescript-eslint": "^7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/code-analyzer-regex-engine": {
+      "version": "0.1.0",
+      "license": "BSD-3-Clause license",
+      "dependencies": {
+        "@salesforce/code-analyzer-engine-api": "0.4.0",
         "@types/node": "^20.0.0"
       },
       "devDependencies": {
@@ -5581,7 +5606,7 @@
       "version": "0.2.0",
       "license": "BSD-3-Clause license",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.3.0",
+        "@salesforce/code-analyzer-engine-api": "0.4.0",
         "@types/node": "^20.0.0",
         "@types/tmp": "^0.2.6",
         "isbinaryfile": "^5.0.2",
@@ -5608,7 +5633,7 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause license",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.3.0",
+        "@salesforce/code-analyzer-engine-api": "0.4.0",
         "@types/node": "^20.0.0"
       },
       "devDependencies": {

--- a/packages/code-analyzer-regex-engine/LICENSE
+++ b/packages/code-analyzer-regex-engine/LICENSE
@@ -1,0 +1,14 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/code-analyzer-regex-engine/eslint.config.mjs
+++ b/packages/code-analyzer-regex-engine/eslint.config.mjs
@@ -1,0 +1,12 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        rules: {
+            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+        }
+    }
+);

--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -8,7 +8,7 @@
     "repository": {
       "type": "git",
       "url": "git+https://github.com/forcedotcom/code-analyzer-core.git",
-      "directory": "packages/code-analyzer-core"
+      "directory": "packages/code-analyzer-regex-engine"
     },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -1,0 +1,63 @@
+{
+    "name": "@salesforce/code-analyzer-regex-engine",
+    "description": "Regex Engine for Salesforce Code Analyzer",
+    "version": "0.1.0",
+    "author": "The Salesforce Code Analyzer Team",
+    "license": "BSD-3-Clause license",
+    "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/forcedotcom/code-analyzer-core.git",
+      "directory": "packages/code-analyzer-core"
+    },
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "dependencies": {
+      "@types/node": "^20.0.0",
+      "@salesforce/code-analyzer-engine-api": "0.4.0"
+    },
+    "devDependencies": {
+      "@eslint/js": "^8.57.0",
+      "@types/jest": "^29.0.0",
+      "eslint": "^8.57.0",
+      "jest": "^29.0.0",
+      "rimraf": "*",
+      "ts-jest": "^29.0.0",
+      "typescript": "^5.4.5",
+      "typescript-eslint": "^7.8.0"
+    },
+    "engines": {
+      "node": ">=20.0.0"
+    },
+    "files": [
+      "dist",
+      "LICENSE",
+      "package.json"
+    ],
+    "scripts": {
+      "build": "tsc --build tsconfig.build.json --verbose",
+      "test": "jest --coverage",
+      "lint": "eslint src/**/*.ts",
+      "package": "npm pack",
+      "all": "npm run build && npm run test && npm run lint && npm run package",
+      "clean": "tsc --build tsconfig.build.json --clean",
+      "postclean": "rimraf dist && rimraf coverage && rimraf ./*.tgz && rimraf vulnerabilities",
+      "scrub": "npm run clean && rimraf node_modules",
+      "showcoverage": "open ./coverage/lcov-report/index.html"
+    },
+    "jest": {
+      "preset": "ts-jest",
+      "testEnvironment": "node",
+      "testMatch": [
+        "**/*.test.ts"
+      ],
+      "testPathIgnorePatterns": [
+        "/node_modules/",
+        "/dist/"
+      ],
+      "collectCoverageFrom": [
+        "src/**/*.ts",
+        "!src/index.ts"
+      ]
+    }
+  }

--- a/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
+++ b/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
@@ -43,7 +43,7 @@ export class RegexEngine extends EngineApi.Engine {
         ];
     }
 
-    async runRules(ruleNames: string[], runOptions: EngineApi.RunOptions): Promise<EngineApi.EngineRunResults> {
+    async runRules(_ruleNames: string[], _runOptions: EngineApi.RunOptions): Promise<EngineApi.EngineRunResults> {
         /* TODO: Update section with logic for implementing trailing whitespace rule*/ 
         return {violations: []};
 

--- a/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
+++ b/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
@@ -2,54 +2,54 @@ import * as EngineApi from '@salesforce/code-analyzer-engine-api/';
 
 export class RegexEnginePlugin extends EngineApi.EnginePluginV1 {
 
-	getAvailableEngineNames(): string[] {
-		return [RegexEngine.NAME];
-	}
+    getAvailableEngineNames(): string[] {
+        return [RegexEngine.NAME];
+    }
 
-	createEngine(engineName: string): EngineApi.Engine {
-		if (engineName === RegexEngine.NAME) {
-			return new RegexEngine()
-		}  else {
-			throw new Error(`Unsupported engine name: ${engineName}`);
-		}
-		
-	}
+    createEngine(engineName: string): EngineApi.Engine {
+        if (engineName === RegexEngine.NAME) {
+            return new RegexEngine()
+        }  else {
+            throw new Error(`Unsupported engine name: ${engineName}`);
+        }
+        
+    }
 
 }
 
 export class RegexEngine extends EngineApi.Engine {
-	static readonly NAME = "regex"
+    static readonly NAME = "regex"
 
-	constructor() {
-		super();
-		
-	}
+    constructor() {
+        super();
+        
+    }
 
-	getName(): string {
-		return RegexEngine.NAME;
-	}
+    getName(): string {
+        return RegexEngine.NAME;
+    }
 
-	async describeRules(): Promise<EngineApi.RuleDescription[]> {
-		return [
-			{
-				name: "TrailingWhitespaceRule",
-				severityLevel: EngineApi.SeverityLevel.Low,
-				type: EngineApi.RuleType.Standard,
-				tags: ["Recommended", "CodeStyle"],
-				/* TODO: Add rule description and resourceUrls for trailing whitespace rule*/ 
-				description: "",
-				resourceUrls: [""]
-			},
-		];
-	}
+    async describeRules(): Promise<EngineApi.RuleDescription[]> {
+        return [
+            {
+                name: "TrailingWhitespaceRule",
+                severityLevel: EngineApi.SeverityLevel.Low,
+                type: EngineApi.RuleType.Standard,
+                tags: ["Recommended", "CodeStyle"],
+                /* TODO: Add rule description and resourceUrls for trailing whitespace rule*/ 
+                description: "",
+                resourceUrls: [""]
+            },
+        ];
+    }
 
-	async runRules(ruleNames: string[], runOptions: EngineApi.RunOptions): Promise<EngineApi.EngineRunResults> {
+    async runRules(ruleNames: string[], runOptions: EngineApi.RunOptions): Promise<EngineApi.EngineRunResults> {
         /* TODO: Update section with logic for implementing trailing whitespace rule*/ 
-		return {violations: []};
+        return {violations: []};
 
-	}
+    }
 
 
 
-	
+    
 }

--- a/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
+++ b/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
@@ -1,0 +1,55 @@
+import * as EngineApi from '@salesforce/code-analyzer-engine-api/';
+
+export class RegexEnginePlugin extends EngineApi.EnginePluginV1 {
+
+	getAvailableEngineNames(): string[] {
+		return [RegexEngine.NAME];
+	}
+
+	createEngine(engineName: string): EngineApi.Engine {
+		if (engineName === RegexEngine.NAME) {
+			return new RegexEngine()
+		}  else {
+			throw new Error(`Unsupported engine name: ${engineName}`);
+		}
+		
+	}
+
+}
+
+export class RegexEngine extends EngineApi.Engine {
+	static readonly NAME = "regex"
+
+	constructor() {
+		super();
+		
+	}
+
+	getName(): string {
+		return RegexEngine.NAME;
+	}
+
+	async describeRules(): Promise<EngineApi.RuleDescription[]> {
+		return [
+			{
+				name: "TrailingWhitespaceRule",
+				severityLevel: EngineApi.SeverityLevel.Low,
+				type: EngineApi.RuleType.Standard,
+				tags: ["Recommended", "CodeStyle"],
+				/* TODO: Add rule description and resourceUrls for trailing whitespace rule*/ 
+				description: "",
+				resourceUrls: [""]
+			},
+		];
+	}
+
+	async runRules(ruleNames: string[], runOptions: EngineApi.RunOptions): Promise<EngineApi.EngineRunResults> {
+        /* TODO: Update section with logic for implementing trailing whitespace rule*/ 
+		return {violations: []};
+
+	}
+
+
+
+	
+}

--- a/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
+++ b/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
@@ -48,8 +48,5 @@ export class RegexEngine extends EngineApi.Engine {
         return {violations: []};
 
     }
-
-
-
-    
+   
 }

--- a/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
+++ b/packages/code-analyzer-regex-engine/src/RegexEnginePlugin.ts
@@ -12,18 +12,11 @@ export class RegexEnginePlugin extends EngineApi.EnginePluginV1 {
         }  else {
             throw new Error(`Unsupported engine name: ${engineName}`);
         }
-        
     }
-
 }
 
 export class RegexEngine extends EngineApi.Engine {
     static readonly NAME = "regex"
-
-    constructor() {
-        super();
-        
-    }
 
     getName(): string {
         return RegexEngine.NAME;
@@ -47,6 +40,5 @@ export class RegexEngine extends EngineApi.Engine {
         /* TODO: Update section with logic for implementing trailing whitespace rule*/ 
         return {violations: []};
 
-    }
-   
+    } 
 }

--- a/packages/code-analyzer-regex-engine/src/index.ts
+++ b/packages/code-analyzer-regex-engine/src/index.ts
@@ -1,0 +1,10 @@
+import {RegexEnginePlugin} from "./RegexEnginePlugin";
+import {EnginePlugin} from "@salesforce/code-analyzer-engine-api";
+
+function createEnginePlugin(): EnginePlugin {
+    return new RegexEnginePlugin();
+}
+
+// Each code analyzer engine plugin module should export its plugin (so that it can be constructed manually) and
+// a createEnginePlugin function that creates the plugin (so that it can be dynamically loaded).
+export { createEnginePlugin, RegexEnginePlugin }

--- a/packages/code-analyzer-regex-engine/src/index.ts
+++ b/packages/code-analyzer-regex-engine/src/index.ts
@@ -1,4 +1,4 @@
-import {RegexEnginePlugin} from "./RegexEnginePlugin";
+import { RegexEnginePlugin } from "./RegexEnginePlugin";
 import {EnginePlugin} from "@salesforce/code-analyzer-engine-api";
 
 function createEnginePlugin(): EnginePlugin {

--- a/packages/code-analyzer-regex-engine/src/index.ts
+++ b/packages/code-analyzer-regex-engine/src/index.ts
@@ -5,6 +5,4 @@ function createEnginePlugin(): EnginePlugin {
     return new RegexEnginePlugin();
 }
 
-// Each code analyzer engine plugin module should export its plugin (so that it can be constructed manually) and
-// a createEnginePlugin function that creates the plugin (so that it can be dynamically loaded).
 export { createEnginePlugin, RegexEnginePlugin }

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -4,7 +4,6 @@ import { changeWorkingDirectoryToPackageRoot } from "./test-helpers";
 
 changeWorkingDirectoryToPackageRoot();
 
-
 describe('Regex Engine Tests', () => {
     let engine: RegexEngine;
     beforeAll(() => {
@@ -16,6 +15,7 @@ describe('Regex Engine Tests', () => {
         expect(name).toEqual("regex");
         
     });
+    
     it('Calling describeRules() on an engine should return the single trailing whitespace rule', async () => {
         const rules_desc: EngineApi.RuleDescription[]= await engine.describeRules();
         const engineRules = [
@@ -29,27 +29,21 @@ describe('Regex Engine Tests', () => {
             },
         ];
         expect(rules_desc).toEqual(engineRules)
-        
     });
 
     it('Confirm runRules() is a no-op', () => {
         const ruleNames: string[] = ['TrailingWhitespaceRule']
         const runOptions: EngineApi.RunOptions = {"workspaceFiles": ["path/to/dir"] }
         engine.runRules(ruleNames, runOptions);
-
     })
 });
 
 describe('RegexEnginePlugin Tests' , () => {
-    
     let pluginEngine: RegexEngine 
     let enginePlugin: RegexEnginePlugin;
-
-
     beforeAll(() => {
         enginePlugin = new RegexEnginePlugin();
         pluginEngine = enginePlugin.createEngine("regex") as RegexEngine;
-
     });
 
     it('Check that I can get all available engine names', () => {
@@ -60,7 +54,6 @@ describe('RegexEnginePlugin Tests' , () => {
     it('Check that engine created from the RegexEnginePlugin has expected name', () => {
         const engineName = "regex";
         expect(pluginEngine.getName()).toStrictEqual(engineName)
-
     });
 
     it('Check that engine created from the RegexEnginePlugin has expected output when describeRules() is called', async () => {
@@ -76,20 +69,16 @@ describe('RegexEnginePlugin Tests' , () => {
         ];
         const engineRules: EngineApi.RuleDescription[] = await pluginEngine.describeRules()
         expect(engineRules).toStrictEqual(expEngineRules)
-
     });
 
     it('Check that engine created from the RegexEnginePlugin has runRules() method as a no-op', () => {
         const ruleNames: string[] = ['TrailingWhitespaceRule']
         const runOptions: EngineApi.RunOptions = {"workspaceFiles": ["path/to/dir"] }
         pluginEngine.runRules(ruleNames, runOptions);
-
-    })
+    });
 
     it('If I make an engine with an invalid name, it should throw an error with the proper error message', () => { 
         expect(() => {enginePlugin.createEngine('OtherEngine')}).toThrow("Unsupported engine name: OtherEngine");
-        
-
     });
     
 });

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -1,0 +1,96 @@
+import { RegexEngine, RegexEnginePlugin} from "../src/RegexEnginePlugin";
+import * as EngineApi from '@salesforce/code-analyzer-engine-api';
+
+
+
+describe('Regex Engine Tests', () => {
+    let engine: RegexEngine;
+    beforeAll(() => {
+        engine = new RegexEngine();
+    });
+
+    it('Check that when I try to access an engine name, it is retrieved and the name is correct', () => {
+        const name: string = engine.getName();
+        expect(name).toEqual("regex");
+        
+    });
+    it('If I call describeRules() on an engine, it should correctly return the single trailing whitespace rule', async () => {
+        const rules_desc: EngineApi.RuleDescription[]= await engine.describeRules();
+        const engineRules = [
+            {
+                name: "TrailingWhitespaceRule",
+                severityLevel: EngineApi.SeverityLevel.Low,
+                type: EngineApi.RuleType.Standard,
+                tags: ["Recommended", "CodeStyle"],
+                description: "",
+                resourceUrls: [""]
+            },
+        ];
+        expect(rules_desc).toEqual(engineRules)
+        
+    });
+
+    it('When I make a call to runRules(), nothing should happen since it is currently a no-op', () => {
+        const ruleNames: string[] = ['TrailingWhitespaceRule']
+        const runOptions: EngineApi.RunOptions = {"workspaceFiles": ["path/to/dir"] }
+        engine.runRules(ruleNames, runOptions);
+
+    })
+});
+
+describe('RegexEnginePlugin Tests' , () => {
+    
+    let pluginEngine: RegexEngine 
+    let enginePlugin: RegexEnginePlugin;
+
+
+    beforeAll(() => {
+        enginePlugin = new RegexEnginePlugin();
+        pluginEngine = enginePlugin.createEngine("regex") as RegexEngine;
+
+    });
+
+    it('Check that I can get all available engine names', () => {
+        const availableEngines: string[] = ['regex'] 
+        expect(enginePlugin.getAvailableEngineNames()).toStrictEqual(availableEngines)
+    })
+   
+    it('Check that engine created from the RegexEnginePlugin has expected name', () => {
+        const engineName = "regex";
+        expect(pluginEngine.getName()).toStrictEqual(engineName)
+
+    });
+
+    it('Check that engine created from the RegexEnginePlugin has expected output when describeRules() is called', async () => {
+        const expEngineRules = [
+            {
+                name: "TrailingWhitespaceRule",
+                severityLevel: EngineApi.SeverityLevel.Low,
+                type: EngineApi.RuleType.Standard,
+                tags: ["Recommended", "CodeStyle"],
+                description: "",
+                resourceUrls: [""]
+            },
+        ];
+        const engineRules: EngineApi.RuleDescription[] = await pluginEngine.describeRules()
+        expect(engineRules).toStrictEqual(expEngineRules)
+
+    });
+
+    it('Check that engine created from the RegexEnginePlugin has runRules() method as a no-op', () => {
+        const ruleNames: string[] = ['TrailingWhitespaceRule']
+        const runOptions: EngineApi.RunOptions = {"workspaceFiles": ["path/to/dir"] }
+        pluginEngine.runRules(ruleNames, runOptions);
+
+    })
+
+    it('If I make an engine with an invalid name, it should throw an error with the proper error message', () => { 
+        expect(() => {enginePlugin.createEngine('OtherEngine')}).toThrow("Unsupported engine name: OtherEngine");
+        
+
+    });
+    
+    
+
+
+});

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -1,6 +1,8 @@
-import { RegexEngine, RegexEnginePlugin} from "../src/RegexEnginePlugin";
+import {RegexEnginePlugin, RegexEngine} from "../src/RegexEnginePlugin";
 import * as EngineApi from '@salesforce/code-analyzer-engine-api';
+import { changeWorkingDirectoryToPackageRoot } from "./test-helpers";
 
+changeWorkingDirectoryToPackageRoot();
 
 
 describe('Regex Engine Tests', () => {
@@ -9,12 +11,12 @@ describe('Regex Engine Tests', () => {
         engine = new RegexEngine();
     });
 
-    it('Check that when I try to access an engine name, it is retrieved and the name is correct', () => {
+    it('Engine name is accessible and correct', () => {
         const name: string = engine.getName();
         expect(name).toEqual("regex");
         
     });
-    it('If I call describeRules() on an engine, it should correctly return the single trailing whitespace rule', async () => {
+    it('Calling describeRules() on an engine should return the single trailing whitespace rule', async () => {
         const rules_desc: EngineApi.RuleDescription[]= await engine.describeRules();
         const engineRules = [
             {
@@ -30,7 +32,7 @@ describe('Regex Engine Tests', () => {
         
     });
 
-    it('When I make a call to runRules(), nothing should happen since it is currently a no-op', () => {
+    it('Confirm runRules() is a no-op', () => {
         const ruleNames: string[] = ['TrailingWhitespaceRule']
         const runOptions: EngineApi.RunOptions = {"workspaceFiles": ["path/to/dir"] }
         engine.runRules(ruleNames, runOptions);

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -92,7 +92,4 @@ describe('RegexEnginePlugin Tests' , () => {
 
     });
     
-    
-
-
 });

--- a/packages/code-analyzer-regex-engine/test/test-helpers.ts
+++ b/packages/code-analyzer-regex-engine/test/test-helpers.ts
@@ -1,0 +1,18 @@
+import process from "node:process";
+import path from "node:path";
+
+export function changeWorkingDirectoryToPackageRoot() {
+    let original_working_directory: string;
+    beforeAll(() => {
+        // We change the directory to ensure that the config files (which use relative folders from the package root)
+        // are processed correctly. The project root directory is typically the one used by default, but it may be
+        // different if the tests are run from the mono-repo's root directory. Lastly, it is better to use the
+        // package root directory is instead of the test directory since some IDEs (like IntelliJ) fail to collect
+        // code coverage correctly unless this package root directory is used.
+        original_working_directory = process.cwd();
+        process.chdir(path.resolve(__dirname,'..'));
+    });
+    afterAll(() => {
+        process.chdir(original_working_directory);
+    });
+}

--- a/packages/code-analyzer-regex-engine/tsconfig.build.json
+++ b/packages/code-analyzer-regex-engine/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src"
+  ],
+  "references": [
+    {
+      "path": "../code-analyzer-engine-api/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/code-analyzer-regex-engine/tsconfig.json
+++ b/packages/code-analyzer-regex-engine/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.build.json",
+    "compilerOptions": {
+      "composite": true,
+      "outDir": "./dist",
+      "rootDir": "."
+    },
+    "include": [
+      "./src",
+      "./test"
+    ]
+  }


### PR DESCRIPTION
In this PR:

* Created project scaffolding to set up the new code-analyzer-regex-engine package
* Created a new RegexPluginEngine that returns a RegexEngine
* runRules() is a no-op

This is the same issue as W-15973916, but due to unsigned commits it was easier to start over from a new branch. This PR addresses comments given on the previous one.