### PR TITLE
NEW (MetadataEngine) @W-16217126@ Scaffolding for metadata engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1304,6 +1304,10 @@
       "resolved": "packages/code-analyzer-eslint-engine",
       "link": true
     },
+    "node_modules/@salesforce/code-analyzer-metadata-engine": {
+      "resolved": "packages/code-analyzer-metadata-engine",
+      "link": true
+    },
     "node_modules/@salesforce/code-analyzer-regex-engine": {
       "resolved": "packages/code-analyzer-regex-engine",
       "link": true
@@ -7065,6 +7069,27 @@
       "devDependencies": {
         "@types/jest": "^29.0.0",
         "cross-env": "^7.0.3",
+        "jest": "^29.0.0",
+        "rimraf": "*",
+        "ts-jest": "^29.0.0",
+        "typescript": "^5.4.5",
+        "typescript-eslint": "^7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/code-analyzer-metadata-engine": {
+      "version": "0.7.0",
+      "license": "BSD-3-Clause license",
+      "dependencies": {
+        "@salesforce/code-analyzer-engine-api": "0.7.0",
+        "@types/node": "^20.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^8.57.0",
+        "@types/jest": "^29.0.0",
+        "eslint": "^8.57.0",
         "jest": "^29.0.0",
         "rimraf": "*",
         "ts-jest": "^29.0.0",

--- a/packages/code-analyzer-metadata-engine/LICENSE
+++ b/packages/code-analyzer-metadata-engine/LICENSE
@@ -1,0 +1,14 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/code-analyzer-metadata-engine/eslint.config.mjs
+++ b/packages/code-analyzer-metadata-engine/eslint.config.mjs
@@ -1,0 +1,12 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        rules: {
+            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+        }
+    }
+);

--- a/packages/code-analyzer-metadata-engine/package.json
+++ b/packages/code-analyzer-metadata-engine/package.json
@@ -1,0 +1,63 @@
+{
+    "name": "@salesforce/code-analyzer-metadata-engine",
+    "description": "Plugin package that adds 'metadata' as an engine into Salesforce Code Analyzer",
+    "version": "0.7.0",
+    "author": "The Salesforce Code Analyzer Team",
+    "license": "BSD-3-Clause license",
+    "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/forcedotcom/code-analyzer-core.git",
+      "directory": "packages/code-analyzer-metadata-engine"
+    },
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "dependencies": {
+      "@types/node": "^20.0.0",
+      "@salesforce/code-analyzer-engine-api": "0.7.0"
+    },
+    "devDependencies": {
+      "@eslint/js": "^8.57.0",
+      "@types/jest": "^29.0.0",
+      "eslint": "^8.57.0",
+      "jest": "^29.0.0",
+      "rimraf": "*",
+      "ts-jest": "^29.0.0",
+      "typescript": "^5.4.5",
+      "typescript-eslint": "^7.8.0"
+    },
+    "engines": {
+      "node": ">=20.0.0"
+    },
+    "files": [
+      "dist",
+      "LICENSE",
+      "package.json"
+    ],
+    "scripts": {
+      "build": "tsc --build tsconfig.build.json --verbose",
+      "test": "jest --coverage",
+      "lint": "eslint src/**/*.ts",
+      "package": "npm pack",
+      "all": "npm run build && npm run test && npm run lint && npm run package",
+      "clean": "tsc --build tsconfig.build.json --clean",
+      "postclean": "rimraf dist && rimraf coverage && rimraf ./*.tgz && rimraf vulnerabilities",
+      "scrub": "npm run clean && rimraf node_modules",
+      "showcoverage": "open ./coverage/lcov-report/index.html"
+    },
+    "jest": {
+      "preset": "ts-jest",
+      "testEnvironment": "node",
+      "testMatch": [
+        "**/*.test.ts"
+      ],
+      "testPathIgnorePatterns": [
+        "/node_modules/",
+        "/dist/"
+      ],
+      "collectCoverageFrom": [
+        "src/**/*.ts",
+        "!src/index.ts"
+      ]
+    }
+  }

--- a/packages/code-analyzer-metadata-engine/src/index.ts
+++ b/packages/code-analyzer-metadata-engine/src/index.ts
@@ -1,0 +1,8 @@
+import { MetadataEnginePlugin } from "./plugin";
+import {EnginePlugin} from "@salesforce/code-analyzer-engine-api";
+
+function createEnginePlugin(): EnginePlugin {
+    return new MetadataEnginePlugin();
+}
+
+export { createEnginePlugin, MetadataEnginePlugin }

--- a/packages/code-analyzer-metadata-engine/src/messages.ts
+++ b/packages/code-analyzer-metadata-engine/src/messages.ts
@@ -1,11 +1,11 @@
 import {getMessageFromCatalog} from "@salesforce/code-analyzer-engine-api";
 
 const MESSAGE_CATALOG : { [key: string]: string } = {
-    TemplateMessage1:
-        `This message has one variable, '%s', in its message.`,
+    CantCreateEngineWithUnknownEngineName:
+        `The MetadataEnginePlugin does not support creating an engine with name '%s'.`,
 
-    TemplateMessage2:
-        `This message has two variables, '%s' and %d, in its message.`
+    PrivateMethodApiVersionRuleDescription:
+        "Enforces a minimum API version for declaring private methods in abstract/virtual apex classes."
 }
 
 /**

--- a/packages/code-analyzer-metadata-engine/src/messages.ts
+++ b/packages/code-analyzer-metadata-engine/src/messages.ts
@@ -1,0 +1,18 @@
+import {getMessageFromCatalog} from "@salesforce/code-analyzer-engine-api";
+
+const MESSAGE_CATALOG : { [key: string]: string } = {
+    TemplateMessage1:
+        `This message has one variable, '%s', in its message.`,
+
+    TemplateMessage2:
+        `This message has two variables, '%s' and %d, in its message.`
+}
+
+/**
+ * getMessage - This is the convenience function to get a message out of the message catalog.
+ * @param msgId - The message identifier
+ * @param args - The arguments that will fill in the %s and %d markers.
+ */
+export function getMessage(msgId: string, ...args: (string | number)[]): string {
+    return getMessageFromCatalog(MESSAGE_CATALOG, msgId, ...args);
+}

--- a/packages/code-analyzer-metadata-engine/src/plugin.ts
+++ b/packages/code-analyzer-metadata-engine/src/plugin.ts
@@ -1,0 +1,54 @@
+import {
+    ConfigObject,
+    DescribeOptions,
+    Engine,
+    EnginePluginV1,
+    EngineRunResults,
+    RuleDescription,
+    RuleType,
+    RunOptions,
+    SeverityLevel,
+} from "@salesforce/code-analyzer-engine-api";
+
+export class MetadataEnginePlugin extends EnginePluginV1 {
+
+    getAvailableEngineNames(): string[] {
+        return [MetadataEngine.NAME];
+    }
+
+    async createEngine(engineName: string, _config: ConfigObject): Promise<Engine> {
+        if (engineName === MetadataEngine.NAME) {
+            return new MetadataEngine()
+        }  else {
+            throw new Error(`Unsupported engine name: ${engineName}`);
+        }
+    }
+}
+
+export class MetadataEngine extends Engine {
+    static readonly NAME = "metadata"
+
+    getName(): string {
+        return MetadataEngine.NAME;
+    }
+
+    async describeRules(_describeOptions: DescribeOptions): Promise<RuleDescription[]> {
+        return [
+            {
+                name: "PrivateMethodAPIVersionRule",
+                severityLevel: SeverityLevel.High,
+                resourceUrls: [],
+                tags: ["Recommended", "Security"],
+                type: RuleType.Standard,
+                description: "Enforces a minimum API version for declaring private methods in abstract/virtual apex classes."
+            }
+        ];
+    }
+
+    async runRules(_ruleNames: string[], _runOptions: RunOptions): Promise<EngineRunResults> {
+        /*TODO: Implement logic for running rules */
+        return {
+            violations: []
+        }
+    }
+}

--- a/packages/code-analyzer-metadata-engine/src/plugin.ts
+++ b/packages/code-analyzer-metadata-engine/src/plugin.ts
@@ -9,6 +9,7 @@ import {
     RunOptions,
     SeverityLevel,
 } from "@salesforce/code-analyzer-engine-api";
+import {getMessage} from "./messages";
 
 export class MetadataEnginePlugin extends EnginePluginV1 {
 
@@ -20,7 +21,7 @@ export class MetadataEnginePlugin extends EnginePluginV1 {
         if (engineName === MetadataEngine.NAME) {
             return new MetadataEngine()
         }  else {
-            throw new Error(`Unsupported engine name: ${engineName}`);
+            throw new Error(getMessage('CantCreateEngineWithUnknownEngineName', engineName));
         }
     }
 }
@@ -40,7 +41,7 @@ export class MetadataEngine extends Engine {
                 resourceUrls: [],
                 tags: ["Recommended", "Security"],
                 type: RuleType.Standard,
-                description: "Enforces a minimum API version for declaring private methods in abstract/virtual apex classes."
+                description: getMessage('PrivateMethodApiVersionRuleDescription')
             }
         ];
     }

--- a/packages/code-analyzer-metadata-engine/src/plugin.ts
+++ b/packages/code-analyzer-metadata-engine/src/plugin.ts
@@ -18,11 +18,10 @@ export class MetadataEnginePlugin extends EnginePluginV1 {
     }
 
     async createEngine(engineName: string, _config: ConfigObject): Promise<Engine> {
-        if (engineName === MetadataEngine.NAME) {
-            return new MetadataEngine()
-        }  else {
+        if (engineName !== MetadataEngine.NAME) {
             throw new Error(getMessage('CantCreateEngineWithUnknownEngineName', engineName));
         }
+        return new MetadataEngine()
     }
 }
 

--- a/packages/code-analyzer-metadata-engine/test/engine.test.ts
+++ b/packages/code-analyzer-metadata-engine/test/engine.test.ts
@@ -1,0 +1,91 @@
+import {changeWorkingDirectoryToPackageRoot} from "./test-helpers";
+import {MetadataEngine, MetadataEnginePlugin} from "../src/plugin";
+import * as testTools from "@salesforce/code-analyzer-engine-api/testtools"
+import {
+    EngineRunResults,
+    RuleDescription,
+    RuleType,
+    SeverityLevel
+} from "@salesforce/code-analyzer-engine-api";
+import {
+    VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION,
+    VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS
+} from "./test-config";
+
+changeWorkingDirectoryToPackageRoot();
+
+describe('Metadata Engine Tests', () => {
+    let engine: MetadataEngine;
+    beforeAll(() => {
+        engine = new MetadataEngine();
+    });
+
+    it('Engine name is accessible and correct', () => {
+        const name: string = engine.getName();
+        expect(name).toEqual("metadata");
+
+    });
+
+    it('Calling describeRules() on an engine should return the single trailing whitespace rule', async () => {
+        const rules_desc: RuleDescription[] = await engine.describeRules({workspace: testTools.createWorkspace([])});
+        const engineRules = [
+            {
+                name: "PrivateMethodAPIVersionRule",
+                severityLevel: SeverityLevel.High,
+                type: RuleType.Standard,
+                tags: ["Recommended", "Security"],
+                description: VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION,
+                resourceUrls: VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS
+            }
+        ];
+        expect(rules_desc).toEqual(engineRules)
+    });
+
+    it("Check that running runRules() is a no-op that just returns an empty list of violations", async () => {
+        const runOptions = {workspace: testTools.createWorkspace([])}
+        const expResults: EngineRunResults = {violations: []}
+        const results = await engine.runRules(["PrivateMethodAPIVersionRule"], runOptions);
+        expect(results).toEqual(expResults)
+    })
+    
+});
+
+describe('MetadataEnginePlugin Tests' , () => {
+    let pluginEngine: MetadataEngine
+    let enginePlugin: MetadataEnginePlugin;
+    beforeAll(async () => {
+        enginePlugin = new MetadataEnginePlugin();
+        pluginEngine = await enginePlugin.createEngine("metadata", {}) as MetadataEngine;
+    });
+
+    it('Check that I can get all available engine names', () => {
+        const availableEngines: string[] = ['metadata']
+        expect(enginePlugin.getAvailableEngineNames()).toStrictEqual(availableEngines)
+    })
+
+    it('Check that engine created from the MetadataEnginePlugin has expected name', () => {
+        const engineName = "metadata";
+        expect(pluginEngine.getName()).toStrictEqual(engineName)
+    });
+
+    it('Check that engine created from the MetadataEnginePlugin has expected output when describeRules is called', async () => {
+        const expEngineRules = [
+            {
+                name: "PrivateMethodAPIVersionRule",
+                severityLevel: SeverityLevel.High,
+                type: RuleType.Standard,
+                tags: ["Recommended", "Security"],
+                description: VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION,
+                resourceUrls: VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS
+            }
+        ];
+        const engineRules: RuleDescription[] = await pluginEngine.describeRules({workspace: testTools.createWorkspace([])})
+        expect(engineRules).toStrictEqual(expEngineRules)
+    });
+
+    it('If I make an engine with an invalid name, it should throw an error with the proper error message', async () => {
+        await expect(enginePlugin.createEngine('OtherEngine', {})).rejects.toThrow("The MetadataEnginePlugin does not support creating an engine with name 'OtherEngine'.");
+    });
+});
+
+

--- a/packages/code-analyzer-metadata-engine/test/engine.test.ts
+++ b/packages/code-analyzer-metadata-engine/test/engine.test.ts
@@ -7,12 +7,13 @@ import {
     RuleType,
     SeverityLevel
 } from "@salesforce/code-analyzer-engine-api";
-import {
-    VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION,
-    VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS
-} from "./test-config";
 
 changeWorkingDirectoryToPackageRoot();
+
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_NAME = "PrivateMethodAPIVersionRule"
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_MESSAGE = "For API versions 60.0 and below, declaring a private method in an abstract or virtual class will override a method with the same signature in a child class. Please update your API version to resolve the issue."
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION = "Enforces a minimum API version for declaring private methods in abstract/virtual apex classes."
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS = []
 
 describe('Metadata Engine Tests', () => {
     let engine: MetadataEngine;
@@ -30,7 +31,7 @@ describe('Metadata Engine Tests', () => {
         const rules_desc: RuleDescription[] = await engine.describeRules({workspace: testTools.createWorkspace([])});
         const engineRules = [
             {
-                name: "PrivateMethodAPIVersionRule",
+                name: VIRTUAL_ABSTRACT_CLASS_API_RULE_NAME,
                 severityLevel: SeverityLevel.High,
                 type: RuleType.Standard,
                 tags: ["Recommended", "Security"],

--- a/packages/code-analyzer-metadata-engine/test/engine.test.ts
+++ b/packages/code-analyzer-metadata-engine/test/engine.test.ts
@@ -7,6 +7,7 @@ import {
     RuleType,
     SeverityLevel
 } from "@salesforce/code-analyzer-engine-api";
+import {getMessage} from "../src/messages";
 
 changeWorkingDirectoryToPackageRoot();
 
@@ -42,12 +43,6 @@ describe('Metadata Engine Tests', () => {
         expect(rules_desc).toEqual(engineRules)
     });
 
-    it("Check that running runRules() is a no-op that just returns an empty list of violations", async () => {
-        const runOptions = {workspace: testTools.createWorkspace([])}
-        const expResults: EngineRunResults = {violations: []}
-        const results = await engine.runRules(["PrivateMethodAPIVersionRule"], runOptions);
-        expect(results).toEqual(expResults)
-    })
 });
 
 describe('MetadataEnginePlugin Tests' , () => {
@@ -84,7 +79,7 @@ describe('MetadataEnginePlugin Tests' , () => {
     });
 
     it('If I make an engine with an invalid name, it should throw an error with the proper error message', async () => {
-        await expect(enginePlugin.createEngine('OtherEngine', {})).rejects.toThrow("The MetadataEnginePlugin does not support creating an engine with name 'OtherEngine'.");
+        await expect(enginePlugin.createEngine('OtherEngine', {})).rejects.toThrow(getMessage('CantCreateEngineWithUnknownEngineName', 'OtherEngine'));
     });
 });
 

--- a/packages/code-analyzer-metadata-engine/test/engine.test.ts
+++ b/packages/code-analyzer-metadata-engine/test/engine.test.ts
@@ -47,7 +47,6 @@ describe('Metadata Engine Tests', () => {
         const results = await engine.runRules(["PrivateMethodAPIVersionRule"], runOptions);
         expect(results).toEqual(expResults)
     })
-    
 });
 
 describe('MetadataEnginePlugin Tests' , () => {

--- a/packages/code-analyzer-metadata-engine/test/test-config.ts
+++ b/packages/code-analyzer-metadata-engine/test/test-config.ts
@@ -1,0 +1,4 @@
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_NAME = "PrivateMethodAPIVersionRule"
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_MESSAGE = "For API versions 60.0 and below, declaring a private method in an abstract or virtual class will override a method with the same signature in a child class. Please update your API version to resolve the issue."
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION = "Enforces a minimum API version for declaring private methods in abstract/virtual apex classes."
+export const VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS = []

--- a/packages/code-analyzer-metadata-engine/test/test-config.ts
+++ b/packages/code-analyzer-metadata-engine/test/test-config.ts
@@ -1,4 +1,0 @@
-export const VIRTUAL_ABSTRACT_CLASS_API_RULE_NAME = "PrivateMethodAPIVersionRule"
-export const VIRTUAL_ABSTRACT_CLASS_API_RULE_MESSAGE = "For API versions 60.0 and below, declaring a private method in an abstract or virtual class will override a method with the same signature in a child class. Please update your API version to resolve the issue."
-export const VIRTUAL_ABSTRACT_CLASS_API_RULE_DESCRIPTION = "Enforces a minimum API version for declaring private methods in abstract/virtual apex classes."
-export const VIRTUAL_ABSTRACT_CLASS_API_RULE_RESOURCE_URLS = []

--- a/packages/code-analyzer-metadata-engine/test/test-helpers.ts
+++ b/packages/code-analyzer-metadata-engine/test/test-helpers.ts
@@ -1,0 +1,18 @@
+import process from "node:process";
+import path from "node:path";
+
+export function changeWorkingDirectoryToPackageRoot() {
+    let original_working_directory: string;
+    beforeAll(() => {
+        // We change the directory to ensure that the config files (which use relative folders from the package root)
+        // are processed correctly. The project root directory is typically the one used by default, but it may be
+        // different if the tests are run from the mono-repo's root directory. Lastly, it is better to use the
+        // package root directory is instead of the test directory since some IDEs (like IntelliJ) fail to collect
+        // code coverage correctly unless this package root directory is used.
+        original_working_directory = process.cwd();
+        process.chdir(path.resolve(__dirname,'..'));
+    });
+    afterAll(() => {
+        process.chdir(original_working_directory);
+    });
+}

--- a/packages/code-analyzer-metadata-engine/tsconfig.build.json
+++ b/packages/code-analyzer-metadata-engine/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src"
+  ],
+  "references": [
+    {
+      "path": "../code-analyzer-engine-api/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/code-analyzer-metadata-engine/tsconfig.json
+++ b/packages/code-analyzer-metadata-engine/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.build.json",
+    "compilerOptions": {
+      "composite": true,
+      "outDir": "./dist",
+      "rootDir": "."
+    },
+    "include": [
+      "./src",
+      "./test"
+    ]
+  }


### PR DESCRIPTION
In this PR:
  
  * New plugin for meta-data based rules
  * Will create a new package called code-analyzer-metadata-engine
  * describeRule() will return a single rule: "PrivateMethodApiVersionRule"
  * runRules() will be a no-op for now