### PR TITLE
FIX(RegexEngine) @W-16441880@ Custom rules without 'g' modifier are not properly handled by engine

### DIFF
--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/code-analyzer-regex-engine",
     "description": "Plugin package that adds 'regex' as an engine into Salesforce Code Analyzer",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause license",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-regex-engine/src/config.ts
+++ b/packages/code-analyzer-regex-engine/src/config.ts
@@ -91,6 +91,11 @@ function validateRegex(value: string, fieldName: string): RegExp {
     }
     const pattern: string = match[1];
     const modifiers: string = match[2];
+
+    if (!modifiers.includes('g')){
+        throw new Error(getMessage('GlobalModifierNotProvided', fieldName, `/${pattern}/g${modifiers}`, value));
+    }
+
     try {
         return new RegExp(pattern, modifiers);
     } catch (err) {

--- a/packages/code-analyzer-regex-engine/src/messages.ts
+++ b/packages/code-analyzer-regex-engine/src/messages.ts
@@ -17,7 +17,10 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
         `The '%s' configuration value is invalid. The value could not be converted into a regular expression: %s`,
 
     InvalidRuleName:
-        `The rule name '%s' defined within the '%s' configuration value is invalid. The rule name must match the regular expression: '%s'`
+        `The rule name '%s' defined within the '%s' configuration value is invalid. The rule name must match the regular expression: '%s'`,
+
+    GlobalModifierNotProvided:
+        `The '%s' configuration value is invalid. The regex engine does not currently support rules without the 'g' modifier. Please use '%s' instead of '%s'.`
 }
 
 /**


### PR DESCRIPTION
In this PR:

*If user does not enable the global modifier flag on their custom regular expression rule, they are dispatched to a custom error message which tells them that the regex engine does not currently support regular expressions w/o the modifier enabled.

NOTE: The reason I chose to not allow users to enable to global modifier for now is that when .match is called with the 'g' flag, the regex matches do not come with important information like the match.index that I need to report violations. So therefore, when 'g' is enabled, I have no choice but to use matchAll(). In theory, I could dispatch between using match/matchAll depending on the 'g' flag but, it just makes the engine more clunky and gives us more code to maintain for a use case that I just can't imagine anyone wanting. I think it's just better to see if users come to us with somewhere it would actually be needed.