### PR TITLE
CHANGE @W-16461375@ Make default severity/tags override-able in rules declaration for regex engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6435,7 +6435,7 @@
     "packages/code-analyzer-core": {
       "name": "@salesforce/code-analyzer-core",
       "version": "0.10.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/js-yaml": "^4.0.9",
@@ -6476,7 +6476,7 @@
     "packages/code-analyzer-engine-api": {
       "name": "@salesforce/code-analyzer-engine-api",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^20.0.0"
       },
@@ -6497,7 +6497,7 @@
     "packages/code-analyzer-eslint-engine": {
       "name": "@salesforce/code-analyzer-eslint-engine",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.24.7",
         "@babel/eslint-parser": "^7.24.7",
@@ -6532,7 +6532,7 @@
     "packages/code-analyzer-flowtest-engine": {
       "name": "@salesforce/code-analyzer-flowtest-engine",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/node": "^20.0.0"
@@ -6554,7 +6554,7 @@
     "packages/code-analyzer-metadata-engine": {
       "name": "@salesforce/code-analyzer-metadata-engine",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/node": "^20.0.0"
@@ -6576,7 +6576,7 @@
     "packages/code-analyzer-pmd-engine": {
       "name": "@salesforce/code-analyzer-pmd-engine",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/node": "^20.0.0"
@@ -6597,8 +6597,8 @@
     },
     "packages/code-analyzer-regex-engine": {
       "name": "@salesforce/code-analyzer-regex-engine",
-      "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "version": "0.8.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/node": "^20.0.0",
@@ -6621,7 +6621,7 @@
     "packages/code-analyzer-retirejs-engine": {
       "name": "@salesforce/code-analyzer-retirejs-engine",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/node": "^20.0.0",
@@ -6648,7 +6648,7 @@
     "packages/T-E-M-P-L-A-T-E": {
       "name": "@salesforce/t-e-m-p-l-a-t-e",
       "version": "0.8.0",
-      "license": "BSD-3-Clause license",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.8.0",
         "@types/node": "^20.0.0"

--- a/packages/code-analyzer-regex-engine/src/config.ts
+++ b/packages/code-analyzer-regex-engine/src/config.ts
@@ -1,5 +1,6 @@
 import {
-    ConfigObject, ConfigValue,
+    ConfigObject,
+    ConfigValue,
     ConfigValueExtractor,
     getMessageFromCatalog,
     RuleDescription,
@@ -53,8 +54,8 @@ export const FILE_EXT_PATTERN: RegExp = /^[.][a-zA-Z0-9]+$/;
 export const RULE_NAME_PATTERN: RegExp = /^[A-Za-z@][A-Za-z_0-9@\-/]*$/;
 export const REGEX_STRING_PATTERN: RegExp = /^\/(.*?)\/(.*)$/;
 
-export const DEFAULT_TAGS: string[] = ['Recommended']
-export const DEFAULT_SEVERITY_LEVEL: SeverityLevel = SeverityLevel.Moderate
+export const DEFAULT_TAGS: string[] = ['Recommended'];
+export const DEFAULT_SEVERITY_LEVEL: SeverityLevel = SeverityLevel.Moderate;
 
 export function validateAndNormalizeConfig(rawConfig: ConfigObject): RegexEngineConfig {
     const valueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.regex');
@@ -62,15 +63,15 @@ export function validateAndNormalizeConfig(rawConfig: ConfigObject): RegexEngine
     const customRules: RegexRules = {};
     for (const ruleName of customRulesExtractor.getKeys()) {
         if (!RULE_NAME_PATTERN.test(ruleName)){
-            throw new Error(getMessage('InvalidRuleName', ruleName, customRulesExtractor.getFieldPath(), RULE_NAME_PATTERN.toString()))
+            throw new Error(getMessage('InvalidRuleName', ruleName, customRulesExtractor.getFieldPath(), RULE_NAME_PATTERN.toString()));
         }
-        const ruleExtractor: ConfigValueExtractor = customRulesExtractor.extractRequiredObjectAsExtractor(ruleName)
-        const description: string = ruleExtractor.extractRequiredString('description')
-        const rawRegexString: string = ruleExtractor.extractRequiredString('regex')
-        const regex: RegExp = validateRegex(rawRegexString, ruleExtractor.getFieldPath('regex'))
+        const ruleExtractor: ConfigValueExtractor = customRulesExtractor.extractRequiredObjectAsExtractor(ruleName);
+        const description: string = ruleExtractor.extractRequiredString('description');
+        const rawRegexString: string = ruleExtractor.extractRequiredString('regex');
+        const regex: RegExp = validateRegex(rawRegexString, ruleExtractor.getFieldPath('regex'));
         const rawFileExtensions: string[] | undefined = ruleExtractor.extractArray('file_extensions',
             (element, fieldPath) => ValueValidator.validateString(element, fieldPath, FILE_EXT_PATTERN));
-        const rawSeverityLevelValue: ConfigValue = ruleExtractor.getObject()['severity_level']
+        const rawSeverityLevelValue: ConfigValue = ruleExtractor.getObject()['severity_level'];
 
         customRules[ruleName] = {
             regex: regex,

--- a/packages/code-analyzer-regex-engine/src/config.ts
+++ b/packages/code-analyzer-regex-engine/src/config.ts
@@ -17,13 +17,16 @@ export type RegexEngineConfig = {
 }
 
 export type RegexRules = {
-    // Rule to be added to the regex engine where the key is the rule name and the value contains the rule definition.
+    // Custom rules to be added to the 'regex' engine of the format custom_rules.<rule_name>.<rule_property_name> = <value> where
+    // <rule_name> is the name you would like to give to your custom rule
     // Example (in yaml format):
     //     NoTodoComments:
     //       regex: /\/\/[ \t]*TODO/gi
     //       file_extensions: [".cls", ".trigger"]
-    //       description: "Prevents TODO comments from being in apex code."
-    //       violation: "A comment with a TODO statement was found. Please remove TODO statements from your apex code."
+    //       description: "Prevents TODO comments from being in Apex code."
+    //       violation: "A comment with a TODO statement was found. Please remove TODO statements from your Apex code."
+    //       severity: "Info"
+    //       tags: ['TechDebt']
     [ruleName: string] : RuleDescription & {
         // The regular expression that triggers a violation when matched against the contents of a file.
         regex: RegExp;
@@ -35,17 +38,17 @@ export type RegexRules = {
         // A description of the rule's purpose.
         description: string;
 
-        // The message emitted when a rule violation occurs. This message is intended to help the user understand the violation.
-        // Default: `A match of the regular expression {regex} was found for rule '{ruleName}': {description}`
+        // [Optional] The message emitted when a rule violation occurs. This message is intended to help the user understand the violation.
+        // Default: `A match of the regular expression <regex> was found for rule '<ruleName>': <description>`
         violation_message: string;
 
-        // A list of labels to help categorize the rule. Rules can also be filtered by these tags.
+        // [Optional] The string array of tag values to apply to this rule by default.
         // Default: ['Recommended']
         tags: string[];
 
-        // Determines the severity level of a rule. You can assign a severity level to a rule to indicate how important the rule is.
-        // The severity levels correspond to numbers as follows: Critical = 1, High = 2, Moderate = 3, Low = 4, Info = 5
-        // Default: Moderate
+        // [Optional] The severity level to apply to this rule by default.
+        // Possible values: 1 or 'Critical', 2 or 'High', 3 or 'Moderate', 4 or 'Low', 5 or 'Info'
+        // Default: 'Moderate'
         severityLevel: SeverityLevel;
     }
 }

--- a/packages/code-analyzer-regex-engine/src/engine.ts
+++ b/packages/code-analyzer-regex-engine/src/engine.ts
@@ -109,7 +109,7 @@ export class RegexEngine extends Engine {
                 codeLocations: [codeLocation],
                 primaryLocationIndex: 0,
                 message: this.regexRules[ruleName].violation_message
-            })
+            });
         }
         return violations;
     }
@@ -138,13 +138,13 @@ function getNewlineIndices(fileContents: string): number[] {
     const newlineIndexes = [-1];
 
     for (const match of matches) {
-        newlineIndexes.push(match.index)
+        newlineIndexes.push(match.index);
     }
     return newlineIndexes;
 }
 
 async function isTextFile(fileName: string): Promise<boolean> {
-    const ext: string = path.extname(fileName).toLowerCase()
+    const ext: string = path.extname(fileName).toLowerCase();
     return TEXT_BASED_FILE_EXTS.has(ext) || !(await isBinaryFile(fileName));
 }
 

--- a/packages/code-analyzer-regex-engine/src/engine.ts
+++ b/packages/code-analyzer-regex-engine/src/engine.ts
@@ -4,6 +4,7 @@ import {
     Engine,
     EngineRunResults,
     RuleDescription,
+    RuleType,
     RunOptions,
     Violation,
     Workspace
@@ -11,7 +12,7 @@ import {
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
-import {RegexRules} from "./config";
+import {RegexRule, RegexRules} from "./config";
 import {isBinaryFile} from "isbinaryfile";
 
 const TEXT_BASED_FILE_EXTS = new Set<string>(
@@ -41,15 +42,12 @@ export class RegexEngine extends Engine {
     }
 
     async describeRules(describeOptions: DescribeOptions): Promise<RuleDescription[]> {
-        if (!describeOptions.workspace) {
-            return Object.values(this.regexRules);
-        }
-        const textFiles: string[] = await this.getTextFiles(describeOptions.workspace)
+        const textFiles: string[] | undefined = describeOptions.workspace ?
+            (await this.getTextFiles(describeOptions.workspace)) : undefined;
         const ruleDescriptions: RuleDescription[] = [];
-
-        for (const regexRule of Object.values(this.regexRules)) {
-            if (textFiles.some(fileName => this.shouldScanFile(fileName, regexRule.name))){
-                ruleDescriptions.push(regexRule);
+        for (const [ruleName, regexRule] of Object.entries(this.regexRules)) {
+            if (!textFiles || textFiles.some(fileName => this.shouldScanFile(fileName, ruleName))){
+                ruleDescriptions.push(toRuleDescription(ruleName, regexRule));
             }
         }
         return ruleDescriptions;
@@ -153,4 +151,15 @@ type AsyncFilterFnc<T> = (value: T) => Promise<boolean>;
 async function filterAsync<T>(array: T[], filterFcn: AsyncFilterFnc<T>): Promise<T[]> {
     const mask: boolean[] = await Promise.all(array.map(filterFcn));
     return array.filter((_, index) => mask[index]);
+}
+
+function toRuleDescription(ruleName: string, regexRule: RegexRule): RuleDescription {
+    return {
+        name: ruleName,
+        severityLevel: regexRule.severity,
+        type: RuleType.Standard,
+        tags: regexRule.tags,
+        description: regexRule.description,
+        resourceUrls: [] // Empty for now. We might allow users to add in resourceUrls if we see a valid use case in the future.
+    }
 }

--- a/packages/code-analyzer-regex-engine/src/messages.ts
+++ b/packages/code-analyzer-regex-engine/src/messages.ts
@@ -20,7 +20,10 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
         `The rule name '%s' defined within the '%s' configuration value is invalid. The rule name must match the regular expression: '%s'`,
 
     GlobalModifierNotProvided:
-        `The '%s' configuration value is invalid. The regex engine does not currently support rules without the 'g' modifier. Please use '%s' instead of '%s'.`
+        `The '%s' configuration value is invalid. The regex engine does not currently support rules without the 'g' modifier. Please use '%s' instead of '%s'.`,
+
+    ConfigValueNotAValidSeverityLevel:
+        `The '%s' configuration value must be one of the following: %s. Instead received: %s`
 }
 
 /**

--- a/packages/code-analyzer-regex-engine/src/plugin.ts
+++ b/packages/code-analyzer-regex-engine/src/plugin.ts
@@ -1,4 +1,4 @@
-import {ConfigObject, Engine, EnginePluginV1, RuleType, SeverityLevel,} from "@salesforce/code-analyzer-engine-api";
+import {ConfigObject, Engine, EnginePluginV1, SeverityLevel,} from "@salesforce/code-analyzer-engine-api";
 import {getMessage} from "./messages";
 import {RegexEngine} from "./engine";
 import {RegexEngineConfig, RegexRules, validateAndNormalizeConfig} from "./config";
@@ -9,11 +9,8 @@ export const BASE_REGEX_RULES: RegexRules = {
         file_extensions: ['.cls', '.trigger'],
         description: getMessage('TrailingWhitespaceRuleDescription'),
         violation_message: getMessage('TrailingWhitespaceRuleMessage'),
-        name: "NoTrailingWhitespace",
-        type: RuleType.Standard,
-        severityLevel: SeverityLevel.Info,
-        tags: ['Recommended', 'CodeStyle'],
-        resourceUrls: []
+        severity: SeverityLevel.Info,
+        tags: ['Recommended', 'CodeStyle']
     }
 }
 

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -116,7 +116,7 @@ describe("Tests for RegexEngine's getName and describeRules methods", () => {
         expect(rulesDescriptions).toHaveLength(3);
         expect(rulesDescriptions[0]).toMatchObject(EXPECTED_NoTrailingWhitespace_RULE_DESCRIPTION);
         expect(rulesDescriptions[1]).toMatchObject(EXPECTED_NoTodos_RULE_DESCRIPTION);
-        expect(rulesDescriptions[2]).toMatchObject(EXPECTED_NoHellos_RULE_DESCRIPTION)
+        expect(rulesDescriptions[2]).toMatchObject(EXPECTED_NoHellos_RULE_DESCRIPTION);
     });
 });
 
@@ -133,8 +133,7 @@ describe('Tests for runRules', () => {
         const runOptions: RunOptions = {
             workspace: new Workspace([
                 path.resolve(__dirname, "test-data", "apexClassWhitespace", "1_notApexClassWithWhitespace")
-            ])
-        };
+            ])};
         const runResults: EngineRunResults = await engine.runRules( ["NoTrailingWhitespace"], runOptions);
         expect(runResults.violations).toHaveLength(0);
     });

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -11,7 +11,11 @@ import {
     Workspace
 } from "@salesforce/code-analyzer-engine-api";
 import {getMessage} from "../src/messages";
-import {RegexRules} from "../src/config";
+import {
+    RegexRules, 
+    DEFAULT_TAGS, 
+    DEFAULT_SEVERITY_LEVEL
+} from "../src/config";
 import {BASE_REGEX_RULES} from "../src/plugin";
 
 changeWorkingDirectoryToPackageRoot();
@@ -24,8 +28,8 @@ const SAMPLE_CUSTOM_RULES: RegexRules = {
         violation_message: "sample violation message",
         name: "NoTodos",
         type: RuleType.Standard,
-        severityLevel: SeverityLevel.Moderate,
-        tags: ['Recommended'],
+        severityLevel: DEFAULT_SEVERITY_LEVEL,
+        tags: DEFAULT_TAGS,
         resourceUrls: []
     },
     NoHellos: {
@@ -34,8 +38,8 @@ const SAMPLE_CUSTOM_RULES: RegexRules = {
         violation_message: "sample violation message",
         name: "NoHellos",
         type: RuleType.Standard,
-        severityLevel: SeverityLevel.Moderate,
-        tags: ['Recommended'],
+        severityLevel: DEFAULT_SEVERITY_LEVEL,
+        tags: DEFAULT_TAGS,
         resourceUrls: []
     }
 };
@@ -51,18 +55,18 @@ const EXPECTED_NoTrailingWhitespace_RULE_DESCRIPTION: RuleDescription = {
 
 const EXPECTED_NoTodos_RULE_DESCRIPTION = {
     name: "NoTodos",
-    severityLevel: SeverityLevel.Moderate,
+    severityLevel: DEFAULT_SEVERITY_LEVEL,
     type: RuleType.Standard,
-    tags: ["Recommended"],
+    tags: DEFAULT_TAGS,
     description: "Detects TODO comments in code base.",
     resourceUrls: []
 };
 
 const EXPECTED_NoHellos_RULE_DESCRIPTION = {
     name: "NoHellos",
-    severityLevel: SeverityLevel.Moderate,
+    severityLevel: DEFAULT_SEVERITY_LEVEL,
     type: RuleType.Standard,
-    tags: ["Recommended"],
+    tags: DEFAULT_TAGS,
     description: "Detects hellos in project.",
     resourceUrls: []
 };

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -26,21 +26,15 @@ const SAMPLE_CUSTOM_RULES: RegexRules = {
         description: "Detects TODO comments in code base.",
         file_extensions: [".js", ".cls"],
         violation_message: "sample violation message",
-        name: "NoTodos",
-        type: RuleType.Standard,
-        severityLevel: DEFAULT_SEVERITY_LEVEL,
-        tags: DEFAULT_TAGS,
-        resourceUrls: []
+        severity: DEFAULT_SEVERITY_LEVEL,
+        tags: DEFAULT_TAGS
     },
     NoHellos: {
         regex: /hello/gi,
         description: "Detects hellos in project.",
         violation_message: "sample violation message",
-        name: "NoHellos",
-        type: RuleType.Standard,
-        severityLevel: DEFAULT_SEVERITY_LEVEL,
-        tags: DEFAULT_TAGS,
-        resourceUrls: []
+        severity: DEFAULT_SEVERITY_LEVEL,
+        tags: DEFAULT_TAGS
     }
 };
 

--- a/packages/code-analyzer-regex-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-regex-engine/test/plugin.test.ts
@@ -332,6 +332,64 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
         expect(pluginEngine._getRegexRules()["NoTodos"].violation_message).toStrictEqual(custom_message);
     });
 
+    it("If user creates a rule with a custom severity level, ensure that is maintained in config", async () => {
+        const rawConfig = {
+            custom_rules: {
+                "NoTodos": {
+                    ...SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
+                    severity_level: SeverityLevel.Critical
+                },
+                "OtherRule": {
+                    ... SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
+                    severity_level: "Critical"
+                }
+            }
+        };
+        const pluginEngine: RegexEngine = await enginePlugin.createEngine("regex", rawConfig) as RegexEngine;
+        expect(pluginEngine._getRegexRules()["NoTodos"].severityLevel).toStrictEqual(SeverityLevel.Critical);
+        expect(pluginEngine._getRegexRules()["OtherRule"].severityLevel).toStrictEqual(SeverityLevel.Critical);
+    });
+
+
+    it("If user creates a rule with an invalid severity level, ensure correct error is emitted", async () => {
+        const rawConfig = {
+            custom_rules: {
+                "NoTodos": {
+                    ...SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
+                    severity_level: 7
+                }
+            }
+        };
+        const severityLevelValues: (string | SeverityLevel)[] = Object.values(SeverityLevel)
+        await expect(enginePlugin.createEngine("regex", rawConfig)).rejects.toThrow(getMessage('ConfigValueNotAValidSeverityLevel', 'engines.regex.custom_rules.NoTodos.severity_level', JSON.stringify(severityLevelValues), '7'));
+    });
+
+    it("If user creates a rule with a custom tags, ensure they are maintained in config", async () => {
+        const customTags: string[] = ["RandomTag"]
+        const rawConfig = {
+            custom_rules: {
+                "NoTodos": {
+                    ...SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
+                    tags: customTags
+                }
+            }
+        };
+        const pluginEngine: RegexEngine = await enginePlugin.createEngine("regex", rawConfig) as RegexEngine;
+        expect(pluginEngine._getRegexRules()["NoTodos"].tags).toStrictEqual(customTags);
+    });
+
+    it("If user creates a rule with tags that are not a string array, ensure correct error is emitted", async () => {
+        const rawConfig = {
+            custom_rules: {
+                "NoTodos": {
+                    ...SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
+                    tags: "RandomTag"
+                }
+            }
+        };
+        await expect(enginePlugin.createEngine("regex", rawConfig)).rejects.toThrow(getMessageFromCatalog(SHARED_MESSAGE_CATALOG,'ConfigValueMustBeOfType', 'engines.regex.custom_rules.NoTodos.tags', 'array', 'string'));
+    });
+
     type PATTERN_TESTCASE = { input: string, expected: RegExp };
     const patternTestCases: PATTERN_TESTCASE[] = [
         // Raw regex strings

--- a/packages/code-analyzer-regex-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-regex-engine/test/plugin.test.ts
@@ -4,7 +4,6 @@ import {
     ConfigObject,
     Engine,
     getMessageFromCatalog,
-    RuleType,
     SeverityLevel,
     SHARED_MESSAGE_CATALOG
 } from "@salesforce/code-analyzer-engine-api";
@@ -67,21 +66,15 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
                 description: SAMPLE_RAW_CUSTOM_RULE_DEFINITION.description,
                 file_extensions: SAMPLE_RAW_CUSTOM_RULE_DEFINITION.file_extensions,
                 violation_message: getMessage('RuleViolationMessage', customNoTodoRuleRegex.toString(), 'NoTodos', 'Detects TODO comments in code base.'),
-                name: "NoTodos",
-                type: RuleType.Standard,
-                severityLevel: SeverityLevel.Moderate,
-                tags: ['Recommended'],
-                resourceUrls: []
+                severity: SeverityLevel.Moderate,
+                tags: ['Recommended']
             },
             NoHellos: {
                 regex: customNoHelloRuleRegex,
                 description: SAMPLE_RAW_CUSTOM_RULE_NO_FILE_EXTS_DEFINITION.description,
                 violation_message: getMessage('RuleViolationMessage', customNoHelloRuleRegex.toString(), 'NoHellos', 'Detects hellos in project'),
-                name: "NoHellos",
-                type: RuleType.Standard,
-                severityLevel: SeverityLevel.Moderate,
-                tags: ['Recommended'],
-                resourceUrls: []
+                severity: SeverityLevel.Moderate,
+                tags: ['Recommended']
             }
         };
         expect(engine._getRegexRules()).toEqual(expRegexRules);
@@ -337,17 +330,17 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
             custom_rules: {
                 "NoTodos": {
                     ...SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
-                    severity_level: SeverityLevel.Critical
+                    severity: SeverityLevel.Critical
                 },
                 "OtherRule": {
                     ... SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
-                    severity_level: "Critical"
+                    severity: "Critical"
                 }
             }
         };
         const pluginEngine: RegexEngine = await enginePlugin.createEngine("regex", rawConfig) as RegexEngine;
-        expect(pluginEngine._getRegexRules()["NoTodos"].severityLevel).toStrictEqual(SeverityLevel.Critical);
-        expect(pluginEngine._getRegexRules()["OtherRule"].severityLevel).toStrictEqual(SeverityLevel.Critical);
+        expect(pluginEngine._getRegexRules()["NoTodos"].severity).toStrictEqual(SeverityLevel.Critical);
+        expect(pluginEngine._getRegexRules()["OtherRule"].severity).toStrictEqual(SeverityLevel.Critical);
     });
 
 
@@ -356,12 +349,12 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
             custom_rules: {
                 "NoTodos": {
                     ...SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
-                    severity_level: 7
+                    severity: 7
                 }
             }
         };
         const severityLevelValues: (string | SeverityLevel)[] = Object.values(SeverityLevel)
-        await expect(enginePlugin.createEngine("regex", rawConfig)).rejects.toThrow(getMessage('ConfigValueNotAValidSeverityLevel', 'engines.regex.custom_rules.NoTodos.severity_level', JSON.stringify(severityLevelValues), '7'));
+        await expect(enginePlugin.createEngine("regex", rawConfig)).rejects.toThrow(getMessage('ConfigValueNotAValidSeverityLevel', 'engines.regex.custom_rules.NoTodos.severity', JSON.stringify(severityLevelValues), '7'));
     });
 
     it("If user creates a rule with a custom tags, ensure they are maintained in config", async () => {


### PR DESCRIPTION
In this PR:

A/C:

* Users can specify tags/severity levels for their custom rules at engines.regex.custom_rules configuration level.
* If a user doesn't give values for these fields, the same defaults as previously defined in configuration documentation will be maintained.