### PR TITLE
CHANGE (RegexEngine) @W-16462482@ Make isTextFile utility async and cache results of isBinaryFile() calls

### DIFF
--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/code-analyzer-regex-engine",
     "description": "Plugin package that adds 'regex' as an engine into Salesforce Code Analyzer",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-regex-engine/test/end-to-end.test.ts
+++ b/packages/code-analyzer-regex-engine/test/end-to-end.test.ts
@@ -22,20 +22,19 @@ describe('End to end test', () => {
             custom_rules: {
                 "NoTodos": {
                     description: "Detects TODO comments in code",
-                    file_extensions: ['.ts', '.cls'],
                     regex: String.raw`/TODO/gi`
                 }
             }
         }
         const engine: Engine = await plugin.createEngine(availableEngineNames[0], customConfig);
-        const workspace: Workspace = new Workspace([path.resolve(__dirname, 'test-data', 'sampleWorkspace')]);
+        const workspace: Workspace = new Workspace([path.resolve(__dirname, 'test-data', 'workspaceWithPythonFile')]);
         const ruleDescriptions: RuleDescription[] = await engine.describeRules({workspace: workspace});
         const recommendedRuleNames: string[] = ruleDescriptions.filter(rd => rd.tags.includes('Recommended')).map(rd => rd.name);
         const engineRunResults: EngineRunResults = await engine.runRules(recommendedRuleNames, {workspace: workspace});
-        const violationsFromTsFile: Violation[] = engineRunResults.violations.filter(v => path.extname(v.codeLocations[0].file) === '.ts');
+        const violationsFromPyFile: Violation[] = engineRunResults.violations.filter(v => path.extname(v.codeLocations[0].file) === '.py');
 
-        expect(violationsFromTsFile).toHaveLength(1);
-        expect(violationsFromTsFile.map(v => v.ruleName)).toEqual(['NoTodos']);
+        expect(violationsFromPyFile).toHaveLength(1);
+        expect(violationsFromPyFile.map(v => v.ruleName)).toEqual(['NoTodos']);
 
         const violationsFromClsFile: Violation[] = engineRunResults.violations.filter(v => path.extname(v.codeLocations[0].file) === '.cls');
 

--- a/packages/code-analyzer-regex-engine/test/engine.test.ts
+++ b/packages/code-analyzer-regex-engine/test/engine.test.ts
@@ -114,7 +114,6 @@ describe("Tests for RegexEngine's getName and describeRules methods", () => {
         expect(rulesDescriptions[1]).toMatchObject(EXPECTED_NoTodos_RULE_DESCRIPTION);
         expect(rulesDescriptions[2]).toMatchObject(EXPECTED_NoHellos_RULE_DESCRIPTION)
     });
-
 });
 
 describe('Tests for runRules', () => {

--- a/packages/code-analyzer-regex-engine/test/test-data/workspaceWithPythonFile/dummy1.py
+++ b/packages/code-analyzer-regex-engine/test/test-data/workspaceWithPythonFile/dummy1.py
@@ -1,0 +1,1 @@
+# TODO: add more code

--- a/packages/code-analyzer-regex-engine/test/test-data/workspaceWithPythonFile/dummy2.cls
+++ b/packages/code-analyzer-regex-engine/test/test-data/workspaceWithPythonFile/dummy2.cls
@@ -1,0 +1,6 @@
+public class dummy {
+   // Additional myOuterClass code here
+   class myInnerClass {
+     // myInnerClass code here
+   }
+} 


### PR DESCRIPTION
In this PR:

* isTextFile() will run asynchronously instead of synchronously
* When a file is checked to see if it is a text file (and will be scanned by rules that iterate through all text files) results are cached so that they can be retrieved so we can reduce calls to costly isBinaryFile() function