### PR TITLE
FIX(eslint): @W-16509878@: Prevent reading babel config files from LWC base config

### DIFF
--- a/packages/code-analyzer-eslint-engine/package.json
+++ b/packages/code-analyzer-eslint-engine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/code-analyzer-eslint-engine",
     "description": "Plugin package that adds 'eslint' as an engine into Salesforce Code Analyzer",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-eslint-engine/src/base-config.ts
+++ b/packages/code-analyzer-eslint-engine/src/base-config.ts
@@ -67,6 +67,8 @@ export class LegacyBaseConfigFactory {
             parserOptions: {
                 requireConfigFile: false,
                 babelOptions: {
+                    babelrc: false,
+                    configFile: false,
                     parserOpts: {
                         plugins: [
                             "classProperties",

--- a/packages/code-analyzer-eslint-engine/src/engine.ts
+++ b/packages/code-analyzer-eslint-engine/src/engine.ts
@@ -103,8 +103,8 @@ export class ESLintEngine extends Engine {
                 if (ruleNames.has(ruleName)) {
                     violations.push(toViolation(eslintResult.filePath, resultMsg));
                 } else {
-                    // This theoretically should never be possible. But for sanity sakes, we'll emit a warning if this ever happens.
-                    this.emitLogEvent(LogLevel.Warn, getMessage('ViolationFoundFromUnregisteredRule', ruleName, JSON.stringify(violation,null,2)))
+                    // This may be possible if a user tries to suppress an eslint rule in their code that isn't available. We just ignore it but debug it just in case.
+                    this.emitLogEvent(LogLevel.Debug, getMessage('ViolationFoundFromUnregisteredRule', ruleName, JSON.stringify(violation,null,2)))
                 }
             }
         }

--- a/packages/code-analyzer-eslint-engine/src/messages.ts
+++ b/packages/code-analyzer-eslint-engine/src/messages.ts
@@ -47,7 +47,9 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
         'ESLint options used: %s',
 
     ViolationFoundFromUnregisteredRule:
-        `A rule with name '%s' produced a violation, but this rule was not registered with the 'eslint' engine so it will not be included in the results. Ignored Violation:\n%s`,
+        `A rule with name '%s' produced a violation, but this rule was not registered with the 'eslint' engine so it will not be included in the results.\n` +
+        `This may occur if in your file you are using inline comments to attempt to disable or configure this rule even though it is unknown to ESLint and Code Analyzer.\n` +
+        `Ignored Violation:\n%s`,
 
     UnusedEslintConfigFile:
         `The ESLint configuration file '%s' was found but not applied.\n` +

--- a/packages/code-analyzer-eslint-engine/src/strategy.ts
+++ b/packages/code-analyzer-eslint-engine/src/strategy.ts
@@ -36,8 +36,7 @@ export class LegacyESLintStrategy implements ESLintStrategy {
      */
     async calculateRulesMetadata(): Promise<Map<string, Rule.RuleMetaData>> {
         const eslintOptions: ESLint.Options = this.createESLintOptions(BaseRuleset.ALL);
-        this.emitLogEvent(LogLevel.Fine, 'Calculating metadata for rules using an ESLint instance with options:\n' +
-            JSON.stringify(eslintOptions,null,2));
+        this.emitLogEvent(LogLevel.Fine, `Calculating metadata for rules with ESLint options: ${JSON.stringify(eslintOptions)}`);
         const ruleModulesMap: Map<string, Rule.RuleModule> = await getAllRuleModules(new LegacyESLint(eslintOptions));
         const rulesMetadata: Map<string, Rule.RuleMetaData> = new Map();
         for (const [ruleName, ruleModule] of ruleModulesMap) {
@@ -74,9 +73,8 @@ export class LegacyESLintStrategy implements ESLintStrategy {
             await this.workspace.getCandidateFilesForUserConfig(filterFcn) :
             await this.workspace.getCandidateFilesForBaseConfig(filterFcn);
 
-        this.emitLogEvent(LogLevel.Fine,
-            `Calculating rule statuses using files ${JSON.stringify(candidateFiles)}\n` +
-            `and an ESLint instance with options:\n${JSON.stringify(eslintOptions,null,2)}`);
+        this.emitLogEvent(LogLevel.Fine, `Calculating rule statuses using files: ${JSON.stringify(candidateFiles)}`);
+        this.emitLogEvent(LogLevel.Fine, `Calculating rule statuses with ESLint options: ${JSON.stringify(eslintOptions)}`);
         this.ruleStatuses = await this.calculateRuleStatusesFor(candidateFiles, eslint);
 
         // Since we have no easy way of turning on a rule that has been explicitly turned off in the config
@@ -118,8 +116,8 @@ export class LegacyESLintStrategy implements ESLintStrategy {
 
         const filesToScan: string[] = await this.workspace.getFilesToScan(filterFcn);
 
-        this.emitLogEvent(LogLevel.Fine, `Running the ESLint.lintFiles method on files ${JSON.stringify(filesToScan)}\n` +
-            `using an ESLint instance with options:\n${JSON.stringify(eslintOptions,null,2)}`);
+        this.emitLogEvent(LogLevel.Fine, `Running the ESLint.lintFiles method on files: ${JSON.stringify(filesToScan)}`);
+        this.emitLogEvent(LogLevel.Fine, `Running the ESLint.lintFiles method with ESLint options: ${JSON.stringify(eslintOptions)}`);
 
         const worker: Worker = new Worker(path.resolve(__dirname,'..', 'worker-scripts', 'run-eslint.mjs'), {
             workerData: {
@@ -177,6 +175,7 @@ export class LegacyESLintStrategy implements ESLintStrategy {
         return {
             cwd: __dirname, // This is needed to make the base plugins discoverable. Don't worry, user's plugins are also still discovered.
             errorOnUnmatchedPattern: false,
+            reportUnusedDisableDirectives: 'off',
             baseConfig: this.baseConfigFactory.createBaseConfig(baseRuleset),   // This is applied first (on bottom).
             useEslintrc: this.config.auto_discover_eslint_config,               // This is applied second.
             overrideConfigFile: userConfigInfo.getUserConfigFile(),             // This is applied third.

--- a/packages/code-analyzer-eslint-engine/test/engine.test.ts
+++ b/packages/code-analyzer-eslint-engine/test/engine.test.ts
@@ -526,6 +526,22 @@ describe('Typical tests for the runRules method of ESLintEngine', () => {
         expect(path.extname(results.violations[0].codeLocations[0].file)).toEqual('.ts');
         expect(path.extname(results.violations[1].codeLocations[0].file)).toEqual('.ts');
     });
+
+    it('When runRules is called on a workspace that has a babel configuration file, then the file is ignored and no error events are thrown', async () => {
+        const folderContainingBabelConfigFile: string = path.join(__dirname, 'test-data','workspaceWithBabelConfigFile');
+        const logEvents: LogEvent[] = [];
+        const engine: ESLintEngine = new ESLintEngine(DEFAULT_CONFIG);
+        const origWorkingDir: string = process.cwd();
+        process.chdir(folderContainingBabelConfigFile);
+        try {
+            const runOptions: RunOptions = {workspace: new Workspace([folderContainingBabelConfigFile])};
+            engine.onEvent(EventType.LogEvent, (event: LogEvent) => logEvents.push(event));
+            await engine.runRules(['@lwc/lwc/no-unexpected-wire-adapter-usages'], runOptions);
+            expect(logEvents.filter(ev => ev.logLevel === LogLevel.Error)).toHaveLength(0);
+        } finally {
+            process.chdir(origWorkingDir);
+        }
+    });
 });
 
 describe('Tests for emitting events', () => {

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithBabelConfigFile/babel.config.js
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithBabelConfigFile/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    presets: [
+        [
+            '@babel/preset-env',
+            {
+                targets: {
+                    node: '16'
+                }
+            }
+        ]
+    ]
+};

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithBabelConfigFile/subDir/.babelrc
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithBabelConfigFile/subDir/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "@babel/preset-env"
+  ]
+}


### PR DESCRIPTION
... and consolidate each fine log even to 1 line each for now (until we add in the ability to control logging better).