### PR TITLE
CHANGE(pmd): @W-17386449@: Small refactor for how we map files to languages

### DIFF
--- a/packages/code-analyzer-pmd-engine/pmd-cpd-wrappers/src/main/java/com/salesforce/sfca/pmdwrapper/PmdRuleDescriber.java
+++ b/packages/code-analyzer-pmd-engine/pmd-cpd-wrappers/src/main/java/com/salesforce/sfca/pmdwrapper/PmdRuleDescriber.java
@@ -105,7 +105,7 @@ class PmdRuleDescriber {
                     // Add rule info
                     PmdRuleInfo pmdRuleInfo = new PmdRuleInfo();
                     pmdRuleInfo.name = rule.getName();
-                    pmdRuleInfo.language = language;
+                    pmdRuleInfo.languageId = language;
                     pmdRuleInfo.description = getLimitedDescription(rule);
                     pmdRuleInfo.externalInfoUrl = rule.getExternalInfoUrl();
                     pmdRuleInfo.ruleSet = rule.getRuleSetName();

--- a/packages/code-analyzer-pmd-engine/pmd-cpd-wrappers/src/main/java/com/salesforce/sfca/pmdwrapper/PmdRuleInfo.java
+++ b/packages/code-analyzer-pmd-engine/pmd-cpd-wrappers/src/main/java/com/salesforce/sfca/pmdwrapper/PmdRuleInfo.java
@@ -2,7 +2,7 @@ package com.salesforce.sfca.pmdwrapper;
 
 class PmdRuleInfo {
     public String name;
-    public String language;
+    public String languageId;
     public String description;
     public String externalInfoUrl;
     public String ruleSet;

--- a/packages/code-analyzer-pmd-engine/pmd-cpd-wrappers/src/test/java/com/salesforce/sfca/pmdwrapper/PmdRuleDescriberTest.java
+++ b/packages/code-analyzer-pmd-engine/pmd-cpd-wrappers/src/test/java/com/salesforce/sfca/pmdwrapper/PmdRuleDescriberTest.java
@@ -59,7 +59,7 @@ public class PmdRuleDescriberTest {
         List<PmdRuleInfo> ruleInfoList = ruleDescriber.describeRulesFor(List.of(), Set.of("apex"));
         assertThat(ruleInfoList.size(), is(greaterThan(0))); // Leaving this flexible. The actual list of rules are tested by typescript tests.
         for (PmdRuleInfo ruleInfo : ruleInfoList) {
-            assertThat(ruleInfo.language, is("apex"));
+            assertThat(ruleInfo.languageId, is("apex"));
         }
 
         // Sanity check one of the rules:
@@ -76,7 +76,7 @@ public class PmdRuleDescriberTest {
         List<PmdRuleInfo> ruleInfoList = ruleDescriber.describeRulesFor(List.of(), Set.of("ecmascript"));
         assertThat(ruleInfoList.size(), is(greaterThan(0))); // Leaving this flexible. The actual list of rules are tested by typescript tests.
         for (PmdRuleInfo ruleInfo : ruleInfoList) {
-            assertThat(ruleInfo.language, is("ecmascript"));
+            assertThat(ruleInfo.languageId, is("ecmascript"));
         }
 
         // Sanity check one of the rules:
@@ -93,7 +93,7 @@ public class PmdRuleDescriberTest {
         List<PmdRuleInfo> ruleInfoList = ruleDescriber.describeRulesFor(List.of(), Set.of("visualforce"));
         assertThat(ruleInfoList.size(), is(greaterThan(0))); // Leaving this flexible. The actual list of rules are tested by typescript tests.
         for (PmdRuleInfo ruleInfo : ruleInfoList) {
-            assertThat(ruleInfo.language, is("visualforce"));
+            assertThat(ruleInfo.languageId, is("visualforce"));
         }
 
         // Sanity check one of the rules:
@@ -110,7 +110,7 @@ public class PmdRuleDescriberTest {
         List<PmdRuleInfo> ruleInfoList = ruleDescriber.describeRulesFor(List.of(), Set.of("xml"));
         assertThat(ruleInfoList.size(), is(greaterThan(0))); // Leaving this flexible. The actual list of rules are tested by typescript tests.
         for (PmdRuleInfo ruleInfo : ruleInfoList) {
-            assertThat(ruleInfo.language, is("xml"));
+            assertThat(ruleInfo.languageId, is("xml"));
         }
 
         // Sanity check one of the rules:
@@ -246,7 +246,7 @@ public class PmdRuleDescriberTest {
     static PmdRuleInfo assertContainsOneRuleWithNameAndLanguage(List<PmdRuleInfo> ruleInfoList, String ruleName, String language) {
         PmdRuleInfo ruleFound = null;
         for (PmdRuleInfo ruleInfo : ruleInfoList) {
-            if (ruleInfo.name.equals(ruleName) && ruleInfo.language.equals(language)) {
+            if (ruleInfo.name.equals(ruleName) && ruleInfo.languageId.equals(language)) {
                 if(ruleFound != null) {
                     throw new RuntimeException("The ruleInfoList contained more than one rule with name \"" + ruleName + "\" and language \"" + language + "\"");
                 }
@@ -261,7 +261,7 @@ public class PmdRuleDescriberTest {
 
     static void assertContainsNoRuleWithNameAndLanguage(List<PmdRuleInfo> ruleInfoList, String ruleName, String language) {
         for (PmdRuleInfo ruleInfo : ruleInfoList) {
-            if (ruleInfo.name.equals(ruleName) && ruleInfo.language.equals(language)) {
+            if (ruleInfo.name.equals(ruleName) && ruleInfo.languageId.equals(language)) {
                 throw new RuntimeException("The ruleInfoList unexpectedly contained a rule with name \"" + ruleName + "\" and language \"" + language + "\"");
             }
         }

--- a/packages/code-analyzer-pmd-engine/src/pmd-wrapper.ts
+++ b/packages/code-analyzer-pmd-engine/src/pmd-wrapper.ts
@@ -9,7 +9,7 @@ const PMD_WRAPPER_LIB_FOLDER: string = path.resolve(__dirname, '..', 'dist', 'ja
 
 export type PmdRuleInfo = {
     name: string,
-    language: string,
+    languageId: string,
     description: string,
     externalInfoUrl: string,
     ruleSet: string,
@@ -63,14 +63,14 @@ export class PmdWrapperInvoker {
         this.emitLogEvent = emitLogEvent;
     }
 
-    async invokeDescribeCommand(customRulesets: string[], pmdRuleLanguages: string[], emitProgress: (percComplete: number) => void): Promise<PmdRuleInfo[]> {
+    async invokeDescribeCommand(customRulesets: string[], pmdRuleLanguageIds: string[], emitProgress: (percComplete: number) => void): Promise<PmdRuleInfo[]> {
         const tempDir: string = await this.getTemporaryWorkingDir();
         const pmdRulesOutputFile: string = path.join(tempDir, 'ruleInfo.json');
         const customRulesetsListFile: string = path.join(tempDir, 'customRulesetsList.txt');
         await fs.promises.writeFile(customRulesetsListFile, customRulesets.join('\n'), 'utf-8');
         emitProgress(10);
 
-        const javaCmdArgs: string[] = [PMD_WRAPPER_JAVA_CLASS, 'describe', pmdRulesOutputFile, customRulesetsListFile, pmdRuleLanguages.join(',')];
+        const javaCmdArgs: string[] = [PMD_WRAPPER_JAVA_CLASS, 'describe', pmdRulesOutputFile, customRulesetsListFile, pmdRuleLanguageIds.join(',')];
         const javaClassPaths: string[] = [
             path.join(PMD_WRAPPER_LIB_FOLDER, '*'),
             ... this.userProvidedJavaClasspathEntries.map(toJavaClasspathEntry)

--- a/packages/code-analyzer-pmd-engine/test/cpd-engine.test.ts
+++ b/packages/code-analyzer-pmd-engine/test/cpd-engine.test.ts
@@ -12,6 +12,7 @@ import {CpdEngine} from "../src/cpd-engine";
 import fs from "node:fs";
 import path from "node:path";
 import {DEFAULT_CPD_ENGINE_CONFIG} from "../src/config";
+import {Language} from "../src/constants";
 
 changeWorkingDirectoryToPackageRoot();
 
@@ -62,7 +63,7 @@ describe('Tests for the describeRules method of PmdEngine', () => {
     it('When selecting only the apex language and no workspace, only apex rule is returned', async () => {
         const engine: CpdEngine = new CpdEngine({
             ... DEFAULT_CPD_ENGINE_CONFIG,
-            rule_languages: ['apex']
+            rule_languages: [Language.APEX]
         });
 
         const ruleDescriptions: RuleDescription[] = await engine.describeRules({});
@@ -73,7 +74,7 @@ describe('Tests for the describeRules method of PmdEngine', () => {
     it('When selecting three languages but workspace only contains files for two of the languages, then only those two rules are returned', async () => {
         const engine: CpdEngine = new CpdEngine({
             ... DEFAULT_CPD_ENGINE_CONFIG,
-            rule_languages: ['apex', 'html', 'xml']
+            rule_languages: [Language.APEX, Language.HTML, Language.XML]
         });
         const workspace: Workspace = new Workspace([
             path.join(TEST_DATA_FOLDER, 'sampleCpdWorkspace', 'ApexClass1_ItselfContainsDuplicateBlocksOfMoreThan100Tokens.cls'),
@@ -226,7 +227,8 @@ describe('Tests for the runRules method of CpdEngine', () => {
         const engine: CpdEngine = new CpdEngine({
             ...DEFAULT_CPD_ENGINE_CONFIG,
             minimum_tokens: {
-                javascript: 10
+                ... DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens,
+                [Language.JAVASCRIPT]: 10
             }
         });
         const progressEvents: RunRulesProgressEvent[] = [];

--- a/packages/code-analyzer-pmd-engine/test/pmd-engine.test.ts
+++ b/packages/code-analyzer-pmd-engine/test/pmd-engine.test.ts
@@ -16,7 +16,7 @@ import {
 import {PmdEngine} from "../src/pmd-engine";
 import fs from "node:fs";
 import path from "node:path";
-import {PMD_VERSION, LanguageId} from "../src/constants";
+import {Language, PMD_VERSION} from "../src/constants";
 import {DEFAULT_PMD_ENGINE_CONFIG, PMD_AVAILABLE_LANGUAGES, PmdEngineConfig} from "../src/config";
 import {PmdCpdEnginesPlugin} from "../src";
 
@@ -132,7 +132,7 @@ describe('Tests for the describeRules method of PmdEngine', () => {
     it('When specifying multiple rule languages, but only js files are in the workspace, then only javascript rules are returned', async () => {
         const engine: PmdEngine = new PmdEngine({
             ... DEFAULT_PMD_ENGINE_CONFIG,
-            rule_languages: ['javascript', 'xml' /* not in workspace */]
+            rule_languages: [Language.JAVASCRIPT, Language.XML /* not in workspace */]
         });
         const workspace: Workspace = new Workspace([
             path.join(TEST_DATA_FOLDER, 'samplePmdWorkspace', 'dummy.js')
@@ -144,7 +144,7 @@ describe('Tests for the describeRules method of PmdEngine', () => {
     it('When adding a custom rulesets from disk, then the custom rules are added to the rule descriptions', async () => {
         const engine: PmdEngine = new PmdEngine({
             ... DEFAULT_PMD_ENGINE_CONFIG,
-            rule_languages: ['apex', 'javascript'],
+            rule_languages: [Language.APEX, Language.JAVASCRIPT],
             custom_rulesets: [
                 path.join(TEST_DATA_FOLDER, 'custom rules', 'somecat3.xml'),
                 path.join(TEST_DATA_FOLDER, 'custom rules', 'subfolder', 'somecat4.xml')
@@ -435,7 +435,7 @@ describe('Tests for the runRules method of PmdEngine', () => {
     it('When specified rules are not relevant to users workspace, then return zero violations', async () => {
         const engine: PmdEngine = new PmdEngine({
             ...DEFAULT_PMD_ENGINE_CONFIG,
-            rule_languages: ['xml']
+            rule_languages: [Language.XML]
         });
         const workspace: Workspace = new Workspace([path.join(TEST_DATA_FOLDER, 'samplePmdWorkspace', 'dummy.xml')]);
         const ruleNames: string[] = ['OperationWithLimitsInLoop', 'VfUnescapeEl'];
@@ -490,7 +490,7 @@ describe('Tests for the runRules method of PmdEngine', () => {
     it('When specifying a non-default language and workspace contains violations for that language, then return correct violations', async () => {
         const engine: PmdEngine = new PmdEngine({
             ... DEFAULT_PMD_ENGINE_CONFIG,
-            rule_languages: ['javascript', 'xml' /* sanity check: not relevant to workspace */, 'apex']
+            rule_languages: [Language.JAVASCRIPT, Language.XML /* sanity check: not relevant to workspace */, Language.APEX]
         });
         const workspace: Workspace = new Workspace([path.join(TEST_DATA_FOLDER, 'samplePmdWorkspace')]);
         const ruleNames: string[] = ['ConsistentReturn', 'WhileLoopsMustUseBraces-javascript', 'MissingEncoding' /* sanity check: not relevant to workspace */, 'OperationWithLimitsInLoop'];
@@ -535,8 +535,8 @@ function expectNoDashesAppearOutsideOfOurLanguageSpecificRules(ruleDescriptions:
     for (const ruleDescription of ruleDescriptions) {
         const dashIdx: number = ruleDescription.name.indexOf('-');
         if (dashIdx >= 0) {
-            const possibleLang: string = ruleDescription.name.substring(dashIdx+1) as LanguageId;
-            if (!(Object.values(LanguageId) as string[]).includes(possibleLang)) {
+            const possibleLang: string = ruleDescription.name.substring(dashIdx+1) as Language;
+            if (!(Object.values(Language) as string[]).includes(possibleLang)) {
                 throw new Error(`${ruleDescription.name} contains a '-' which is a reserved character for our PMD rules`)
             }
         }


### PR DESCRIPTION
This refactor includes:
* Renaming LanguageId to Language when referring to the enum on the code analyzer side and using languageId to refer to the pmd/cpd language id to remove confusion from the code.
* Make the resolved config use Language enum instead of string so that the engines don't need to convert from string
* Prepare to make configurable file_extensions field by introducing the DEFAULT_FILE_EXTENSIONS map (to replace the old extensionToLanguageId map) that gets converted using toExtensionsToLanguageMap utility method.