### PR TITLE
CHANGE @W-17397557@ Core now prepends node homedir onto PATH (2 of 2)

### DIFF
--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -21,6 +21,7 @@ import {
     UniqueIdGenerator
 } from "./utils";
 import fs from "node:fs";
+import path from 'node:path';
 
 export interface Workspace {
     getWorkspaceId(): string
@@ -61,6 +62,8 @@ export class CodeAnalyzer {
         if (semver.major < MINIMUM_SUPPORTED_NODE) {
             throw new Error(getMessage('UnsupportedNodeVersion', MINIMUM_SUPPORTED_NODE, version));
         }
+        const nodeHomeDir: string = path.dirname(process.execPath);
+        process.env.PATH = `${nodeHomeDir}${path.delimiter}${process.env.PATH}`;
     }
 
     // For testing purposes only

--- a/packages/code-analyzer-core/test/code-analyzer.test.ts
+++ b/packages/code-analyzer-core/test/code-analyzer.test.ts
@@ -42,6 +42,18 @@ describe("Tests for CodeAnalyzer constructor", () => {
     ])('When supplied with a Node Version of v20 or later, construction succeeds. Case: $version"', ({version}) => {
         expect(new CodeAnalyzer(CodeAnalyzerConfig.withDefaults(), version)).toBeInstanceOf(CodeAnalyzer);
     });
+
+    it("Constructor prepends the currently-running Node's parent folder to the PATH", () => {
+        // Figure out what the current value of PATH is.
+        const initialPath: string = process.env.PATH || '';
+        const nodeParentDir: string = path.dirname(process.execPath);
+
+        // Instantiate a Code Analyzer.
+        const codeAnalyzer: CodeAnalyzer = new CodeAnalyzer(CodeAnalyzerConfig.withDefaults());
+
+        // Verify that the PATH was changed.
+        expect(process.env.PATH).toEqual(`${nodeParentDir}${path.delimiter}${initialPath}`);
+    });
 });
 
 describe("Tests for the run method of CodeAnalyzer", () => {


### PR DESCRIPTION
This is the second of two PRs that collectively constitute User Story W-17397558.
This PR causes the Code Analyzer Core constructor to prepend the `process.env.PATH` variable with the parent directory of the currently-executing version of node, thus allowing RetireJS (and anything else that depends on a Node child process) to work even Node is not present on the system's PATH variable.