### PR TITLE
NEW: @W-16371174@: Make all configuration settings case insensitive

### DIFF
--- a/packages/T-E-M-P-L-A-T-E/package.json
+++ b/packages/T-E-M-P-L-A-T-E/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/t-e-m-p-l-a-t-e",
     "description": "T-E-M-P-L-A-T-E",
-    "version": "0.15.0",
+    "version": "0.16.0-SNAPSHOT",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -14,7 +14,7 @@
     "types": "dist/index.d.ts",
     "dependencies": {
       "@types/node": "^20.0.0",
-      "@salesforce/code-analyzer-engine-api": "0.15.0"
+      "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT"
     },
     "devDependencies": {
       "@eslint/js": "^8.57.1",

--- a/packages/code-analyzer-core/package.json
+++ b/packages/code-analyzer-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-core",
   "description": "Core Package for the Salesforce Code Analyzer",
-  "version": "0.18.1-SNAPSHOT",
+  "version": "0.19.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.15.0",
+    "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@types/sarif": "^2.1.7",

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -273,6 +273,10 @@ export class CodeAnalyzer {
         const engineConfigValueExtractor: engApi.ConfigValueExtractor = new engApi.ConfigValueExtractor(
             engineOverrides as engApi.ConfigObject, `${FIELDS.ENGINES}.${engineName}`, this.config.getConfigRoot());
 
+        // Although not truly a hidden field (it is well documented), we mark 'disable_engine' as a hidden field on the
+        // extractor so that each engine doesn't need to list it when using the validateOnlyContainsKeys method.
+        engineConfigValueExtractor._addHiddenKeys([FIELDS.DISABLE_ENGINE]);
+
         try {
             const engineConfig: engApi.ConfigObject = await enginePluginV1.createEngineConfig(engineName, engineConfigValueExtractor);
             const engine: engApi.Engine = await enginePluginV1.createEngine(engineName, engineConfig);

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -273,9 +273,9 @@ export class CodeAnalyzer {
         const engineConfigValueExtractor: engApi.ConfigValueExtractor = new engApi.ConfigValueExtractor(
             engineOverrides as engApi.ConfigObject, `${FIELDS.ENGINES}.${engineName}`, this.config.getConfigRoot());
 
-        // Although not truly a hidden field (it is well documented), we mark 'disable_engine' as a hidden field on the
-        // extractor so that each engine doesn't need to list it when using the validateOnlyContainsKeys method.
-        engineConfigValueExtractor._addHiddenKeys([FIELDS.DISABLE_ENGINE]);
+        // We mark 'disable_engine' as a key that the extractor should not worry about with validation so that each
+        // engine doesn't need to list it when using the validateContainsOnlySpecifiedKeys method.
+        engineConfigValueExtractor.addKeysThatBypassValidation([FIELDS.DISABLE_ENGINE]);
 
         try {
             const engineConfig: engApi.ConfigObject = await enginePluginV1.createEngineConfig(engineName, engineConfigValueExtractor);

--- a/packages/code-analyzer-core/src/config.ts
+++ b/packages/code-analyzer-core/src/config.ts
@@ -98,8 +98,8 @@ export class CodeAnalyzerConfig {
         configRoot = !rawConfig.config_root ? (configRoot ?? process.cwd()) :
             validateAbsoluteFolder(rawConfig.config_root, FIELDS.CONFIG_ROOT);
         const configExtractor: engApi.ConfigValueExtractor = new engApi.ConfigValueExtractor(rawConfig, '', configRoot);
-        configExtractor._addHiddenKeys([FIELDS.CUSTOM_ENGINE_PLUGIN_MODULES]);
-        configExtractor.validateOnlyContainsKeys([FIELDS.CONFIG_ROOT, FIELDS.LOG_FOLDER ,FIELDS.RULES, FIELDS.ENGINES]);
+        configExtractor.addKeysThatBypassValidation([FIELDS.CUSTOM_ENGINE_PLUGIN_MODULES]); // Because custom_engine_plugin_modules is currently hidden
+        configExtractor.validateContainsOnlySpecifiedKeys([FIELDS.CONFIG_ROOT, FIELDS.LOG_FOLDER ,FIELDS.RULES, FIELDS.ENGINES]);
         const config: TopLevelConfig = {
             config_root: configRoot,
             log_folder: configExtractor.extractFolder(FIELDS.LOG_FOLDER, DEFAULT_CONFIG.log_folder)!,
@@ -191,7 +191,7 @@ function extractRuleOverridesFrom(engineRuleOverridesExtractor: engApi.ConfigVal
 }
 
 function extractRuleOverrideFrom(ruleOverrideExtractor: engApi.ConfigValueExtractor): RuleOverride {
-    ruleOverrideExtractor.validateOnlyContainsKeys([FIELDS.SEVERITY, FIELDS.TAGS]);
+    ruleOverrideExtractor.validateContainsOnlySpecifiedKeys([FIELDS.SEVERITY, FIELDS.TAGS]);
     const engSeverity: engApi.SeverityLevel | undefined = ruleOverrideExtractor.extractSeverityLevel(FIELDS.SEVERITY);
     return {
         tags: ruleOverrideExtractor.extractArray(FIELDS.TAGS, engApi.ValueValidator.validateString),

--- a/packages/code-analyzer-core/src/config.ts
+++ b/packages/code-analyzer-core/src/config.ts
@@ -10,7 +10,7 @@ import {SeverityLevel} from "./rules";
 export const FIELDS = {
     CONFIG_ROOT: 'config_root',
     LOG_FOLDER: 'log_folder',
-    CUSTOM_ENGINE_PLUGIN_MODULES: 'custom_engine_plugin_modules',
+    CUSTOM_ENGINE_PLUGIN_MODULES: 'custom_engine_plugin_modules', // Hidden
     RULES: 'rules',
     ENGINES: 'engines',
     SEVERITY: 'severity',
@@ -98,6 +98,8 @@ export class CodeAnalyzerConfig {
         configRoot = !rawConfig.config_root ? (configRoot ?? process.cwd()) :
             validateAbsoluteFolder(rawConfig.config_root, FIELDS.CONFIG_ROOT);
         const configExtractor: engApi.ConfigValueExtractor = new engApi.ConfigValueExtractor(rawConfig, '', configRoot);
+        configExtractor._addHiddenKeys([FIELDS.CUSTOM_ENGINE_PLUGIN_MODULES]);
+        configExtractor.validateOnlyContainsKeys([FIELDS.CONFIG_ROOT, FIELDS.LOG_FOLDER ,FIELDS.RULES, FIELDS.ENGINES]);
         const config: TopLevelConfig = {
             config_root: configRoot,
             log_folder: configExtractor.extractFolder(FIELDS.LOG_FOLDER, DEFAULT_CONFIG.log_folder)!,
@@ -159,15 +161,15 @@ export class CodeAnalyzerConfig {
     }
 
     public getRuleOverridesFor(engineName: string): RuleOverrides {
-        return this.config.rules[engineName] || {};
+        return engApi.getValueUsingCaseInsensitiveKey(this.config.rules, engineName) as RuleOverrides || {};
     }
 
     public getRuleOverrideFor(engineName: string, ruleName: string): RuleOverride {
-        return this.getRuleOverridesFor(engineName)[ruleName] || {};
+        return engApi.getValueUsingCaseInsensitiveKey(this.getRuleOverridesFor(engineName), ruleName) as RuleOverride || {};
     }
 
     public getEngineOverridesFor(engineName: string): EngineOverrides {
-        return this.config.engines[engineName] || {};
+        return engApi.getValueUsingCaseInsensitiveKey(this.config.engines, engineName) as EngineOverrides || {};
     }
 }
 
@@ -189,6 +191,7 @@ function extractRuleOverridesFrom(engineRuleOverridesExtractor: engApi.ConfigVal
 }
 
 function extractRuleOverrideFrom(ruleOverrideExtractor: engApi.ConfigValueExtractor): RuleOverride {
+    ruleOverrideExtractor.validateOnlyContainsKeys([FIELDS.SEVERITY, FIELDS.TAGS]);
     const engSeverity: engApi.SeverityLevel | undefined = ruleOverrideExtractor.extractSeverityLevel(FIELDS.SEVERITY);
     return {
         tags: ruleOverrideExtractor.extractArray(FIELDS.TAGS, engApi.ValueValidator.validateString),

--- a/packages/code-analyzer-core/test/config.test.ts
+++ b/packages/code-analyzer-core/test/config.test.ts
@@ -57,6 +57,7 @@ describe("Tests for creating and accessing configuration values", () => {
                 tags: ['Security', "SomeNewTag"]
             }
         });
+        expect(conf.getRuleOverrideFor('STUBENGINE1','STUB1RULED')).toEqual(conf.getRuleOverrideFor('stubEngine1','stub1RuleD')); // Sanity test for case insensitivity
         expect(conf.getEngineOverridesFor('stubEngine1')).toEqual({});
         expect(conf.getEngineOverridesFor('stubEngine2')).toEqual({});
     });
@@ -85,6 +86,7 @@ describe("Tests for creating and accessing configuration values", () => {
                 severity: SeverityLevel.Moderate
             }
         });
+        expect(conf.getRuleOverridesFor('STUbengine2')).toEqual(conf.getRuleOverridesFor('stubEngine2'));  // Also test case insensitivity
         expect(conf.getEngineOverridesFor('stubEngine1')).toEqual({
             miscSetting1: true,
             miscSetting2: {
@@ -92,6 +94,7 @@ describe("Tests for creating and accessing configuration values", () => {
                 miscSetting2B: ["hello", "world"]
             }
         });
+        expect(conf.getEngineOverridesFor('stubENGINE1')).toEqual(conf.getEngineOverridesFor('stubEngine1')); // Also test case insensitivity
         expect(conf.getEngineOverridesFor('stubEngine2')).toEqual({});
     });
 
@@ -165,6 +168,12 @@ describe("Tests for creating and accessing configuration values", () => {
             getMessage('ConfigContentNotAnObject','array'));
     });
 
+    it("When top level config has an unknown key, then we error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({doesNotExist: 3})).toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG,'ConfigObjectContainsInvalidKey','<TopLevel>', 'doesNotExist',
+                '["config_root","log_folder","rules","engines"]'));
+    });
+
     it("When engines value is not an object then we throw an error", () => {
         expect(() => CodeAnalyzerConfig.fromObject({engines: ['oops']})).toThrow(
             getMessageFromCatalog(SHARED_MESSAGE_CATALOG,'ConfigValueMustBeOfType','engines', 'object', 'array'));
@@ -188,6 +197,12 @@ describe("Tests for creating and accessing configuration values", () => {
     it("When rules.someEngine.someRule is not an object then we throw an error", () => {
         expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {someRule: [1,2]}}})).toThrow(
             getMessageFromCatalog(SHARED_MESSAGE_CATALOG,'ConfigValueMustBeOfType','rules.someEngine.someRule', 'object', 'array'));
+    });
+
+    it("When rules.someEngine.someRule contains an unknown key then we throw an error", () => {
+        expect(() => CodeAnalyzerConfig.fromObject({rules: {someEngine: {someRule: {oops: 3, tags: []}}}})).toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG,'ConfigObjectContainsInvalidKey','rules.someEngine.someRule', 'oops',
+                '["severity","tags"]'));
     });
 
     it("When the severity of a rule not a valid value then we throw an error", () => {

--- a/packages/code-analyzer-engine-api/package.json
+++ b/packages/code-analyzer-engine-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-engine-api",
   "description": "Engine API Package for the Salesforce Code Analyzer",
-  "version": "0.15.0",
+  "version": "0.16.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-engine-api/src/config.ts
+++ b/packages/code-analyzer-engine-api/src/config.ts
@@ -44,11 +44,16 @@ export class ConfigValueExtractor {
     private readonly configObj: ConfigObject;
     private readonly fieldPathRoot: string;
     private readonly configRoot: string;
+    private hiddenKeys: string[] = [];
 
     constructor(configObject: ConfigObject, fieldPathRoot: string = '', configRoot: string = process.cwd()) {
         this.configObj = configObject;
         this.fieldPathRoot = fieldPathRoot;
         this.configRoot = configRoot;
+    }
+
+    _addHiddenKeys(hiddenKeys: string[]) {
+        this.hiddenKeys = this.hiddenKeys.concat(hiddenKeys);
     }
 
     getObject(): ConfigObject {
@@ -63,99 +68,135 @@ export class ConfigValueExtractor {
         return this.configRoot;
     }
 
-    extractRequiredBoolean(fieldName: string): boolean {
-        return ValueValidator.validateBoolean(this.configObj[fieldName], this.getFieldPath(fieldName));
+    validateOnlyContainsKeys(keys: string[]) {
+        const actualKeys: string[] = this.getKeys();
+        const lowercasePublicKeys: string[] = keys.map(k => k.toLowerCase());
+        for (const key of actualKeys) {
+            if (!lowercasePublicKeys.includes(key.toLowerCase()) && !this.hiddenKeys.includes(key)) {
+                throw new Error(getMessage('ConfigObjectContainsInvalidKey',
+                    this.fieldPathRoot || '<TopLevel>', key, JSON.stringify(keys)))
+            }
+        }
     }
 
-    extractBoolean(fieldName: string, defaultValue?: boolean): boolean | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredBoolean(fieldName);
-    }
-
-    extractRequiredNumber(fieldName: string): number {
-        return ValueValidator.validateNumber(this.configObj[fieldName], this.getFieldPath(fieldName));
-    }
-
-    extractNumber(fieldName: string, defaultValue?: number): number | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredNumber(fieldName);
-    }
-
-    extractRequiredString(fieldName: string, regexpToMatch?: RegExp): string {
-        return ValueValidator.validateString(this.configObj[fieldName], this.getFieldPath(fieldName), regexpToMatch);
-    }
-
-    extractString(fieldName: string, defaultValue?: string, regexpToMatch?: RegExp): string | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredString(fieldName, regexpToMatch);
-    }
-
-    extractRequiredSeverityLevel(fieldName: string): SeverityLevel {
-        return ValueValidator.validateSeverityLevel(this.configObj[fieldName], this.getFieldPath(fieldName));
-    }
-
-    extractSeverityLevel(fieldName: string, defaultValue?: SeverityLevel): SeverityLevel | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredSeverityLevel(fieldName);
-    }
-
-    extractRequiredObject(fieldName: string): ConfigObject {
-        return ValueValidator.validateObject(this.configObj[fieldName], this.getFieldPath(fieldName)) as ConfigObject;
-    }
-
-    extractRequiredObjectAsExtractor(fieldName: string): ConfigValueExtractor {
-        const subObject: ConfigObject = this.extractRequiredObject(fieldName);
-        return new ConfigValueExtractor(subObject, this.getFieldPath(fieldName));
-    }
-
-    extractObject(fieldName: string, defaultValue?: ConfigObject): ConfigObject | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredObject(fieldName);
-    }
-
-    extractObjectAsExtractor(fieldName: string, defaultValue?: ConfigObject): ConfigValueExtractor {
-        const subObject: ConfigObject = this.extractObject(fieldName, defaultValue) || {};
-        return new ConfigValueExtractor(subObject, this.getFieldPath(fieldName));
-    }
-
-    extractRequiredArray<T>(fieldName: string, elementValidator?: (element: unknown, elementFieldName: string) => T): T[] {
-        return ValueValidator.validateArray<T>(this.configObj[fieldName], this.getFieldPath(fieldName), elementValidator);
-    }
-
-    extractArray<T>(fieldName: string, elementValidator?: (element: unknown, elementFieldName: string) => T, defaultValue?: T[]): T[] | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredArray(fieldName, elementValidator);
-    }
-
-    extractRequiredObjectArrayAsExtractorArray(fieldName: string): ConfigValueExtractor[] {
-        const subObjects: ConfigObject[] = this.extractRequiredArray(fieldName, ValueValidator.validateObject);
-        return subObjects.map((elem, index) => new ConfigValueExtractor(elem, `${this.getFieldPath(fieldName)}[${index}]`));
-    }
-
-    extractObjectArrayAsExtractorArray(fieldName: string, defaultValue?: ConfigObject[]): ConfigValueExtractor[] {
-        const subObjects: ConfigObject[] = this.extractArray(fieldName, ValueValidator.validateObject, defaultValue) || [];
-        return subObjects.map((elem, index) => new ConfigValueExtractor(elem, `${this.getFieldPath(fieldName)}[${index}]`));
-    }
-
-    extractRequiredFile(fieldName: string): string {
-        return ValueValidator.validateFile(this.configObj[fieldName], this.getFieldPath(fieldName), [this.getConfigRoot()]);
-    }
-
-    extractFile(fieldName: string, defaultValue?: string): string | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredFile(fieldName);
-    }
-
-    extractRequiredFolder(fieldName: string): string {
-        return ValueValidator.validateFolder(this.configObj[fieldName], this.getFieldPath(fieldName), [this.getConfigRoot()]);
-    }
-
-    extractFolder(fieldName: string, defaultValue?: string): string | undefined {
-        return !this.hasValueDefinedFor(fieldName) ? defaultValue : this.extractRequiredFolder(fieldName);
-    }
-
-    getFieldPath(fieldName?: string): string {
-        if (!fieldName) {
+    getFieldPath(key?: string): string {
+        if (!key) {
             return this.fieldPathRoot;
         }
-        return this.fieldPathRoot.length > 0 ? `${this.fieldPathRoot}.${fieldName}` : fieldName;
+        return this.fieldPathRoot.length > 0 ? `${this.fieldPathRoot}.${key}` : key;
     }
 
-    hasValueDefinedFor(fieldName: string): boolean {
-        return this.configObj[fieldName] !== undefined && this.configObj[fieldName] !== null;
+    hasValueDefinedFor(key: string): boolean {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return value !== null;
+    }
+
+
+    /** ==== BOOLEAN VALUE EXTRACTION ==== **/
+    extractRequiredBoolean(key: string): boolean {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateBoolean(value, this.getFieldPath(key));
+    }
+
+    extractBoolean(key: string, defaultValue?: boolean): boolean | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredBoolean(key);
+    }
+
+
+    /** ==== NUMBER VALUE EXTRACTION ==== **/
+    extractRequiredNumber(key: string): number {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateNumber(value, this.getFieldPath(key));
+    }
+
+    extractNumber(key: string, defaultValue?: number): number | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredNumber(key);
+    }
+
+
+    /** ==== STRING VALUE EXTRACTION ==== **/
+    extractRequiredString(key: string, regexpToMatch?: RegExp): string {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateString(value, this.getFieldPath(key), regexpToMatch);
+    }
+
+    extractString(key: string, defaultValue?: string, regexpToMatch?: RegExp): string | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredString(key, regexpToMatch);
+    }
+
+
+    /** ==== SeverityLevel VALUE EXTRACTION ==== **/
+    extractRequiredSeverityLevel(key: string): SeverityLevel {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateSeverityLevel(value, this.getFieldPath(key));
+    }
+
+    extractSeverityLevel(key: string, defaultValue?: SeverityLevel): SeverityLevel | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredSeverityLevel(key);
+    }
+
+
+    /** ==== OBJECT VALUE EXTRACTION ==== **/
+    extractRequiredObject(key: string): ConfigObject {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateObject(value, this.getFieldPath(key)) as ConfigObject;
+    }
+
+    extractRequiredObjectAsExtractor(key: string): ConfigValueExtractor {
+        const subObject: ConfigObject = this.extractRequiredObject(key);
+        return new ConfigValueExtractor(subObject, this.getFieldPath(key));
+    }
+
+    extractObject(key: string, defaultValue?: ConfigObject): ConfigObject | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredObject(key);
+    }
+
+    extractObjectAsExtractor(key: string, defaultValue?: ConfigObject): ConfigValueExtractor {
+        const subObject: ConfigObject = this.extractObject(key, defaultValue) || {};
+        return new ConfigValueExtractor(subObject, this.getFieldPath(key));
+    }
+
+
+    /** ==== ARRAY VALUE EXTRACTION ==== **/
+    extractRequiredArray<T>(key: string, elementValidator?: (element: unknown, elementFieldPath: string) => T): T[] {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateArray<T>(value, this.getFieldPath(key), elementValidator);
+    }
+
+    extractArray<T>(key: string, elementValidator?: (element: unknown, elementFieldPath: string) => T, defaultValue?: T[]): T[] | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredArray(key, elementValidator);
+    }
+
+    extractRequiredObjectArrayAsExtractorArray(key: string): ConfigValueExtractor[] {
+        const subObjects: ConfigObject[] = this.extractRequiredArray(key, ValueValidator.validateObject);
+        return subObjects.map((elem, index) => new ConfigValueExtractor(elem, `${this.getFieldPath(key)}[${index}]`));
+    }
+
+    extractObjectArrayAsExtractorArray(key: string, defaultValue?: ConfigObject[]): ConfigValueExtractor[] {
+        const subObjects: ConfigObject[] = this.extractArray(key, ValueValidator.validateObject, defaultValue) || [];
+        return subObjects.map((elem, index) => new ConfigValueExtractor(elem, `${this.getFieldPath(key)}[${index}]`));
+    }
+
+
+    /** ==== FILE PATH EXTRACTION ==== **/
+    extractRequiredFile(key: string): string {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateFile(value, this.getFieldPath(key), [this.getConfigRoot()]);
+    }
+
+    extractFile(key: string, defaultValue?: string): string | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredFile(key);
+    }
+
+
+    /** ==== FOLDER PATH EXTRACTION ==== **/
+    extractRequiredFolder(key: string): string {
+        const value: ConfigValue = getValueUsingCaseInsensitiveKey(this.configObj, key);
+        return ValueValidator.validateFolder(value, this.getFieldPath(key), [this.getConfigRoot()]);
+    }
+
+    extractFolder(key: string, defaultValue?: string): string | undefined {
+        return !this.hasValueDefinedFor(key) ? defaultValue : this.extractRequiredFolder(key);
     }
 }
 
@@ -198,7 +239,7 @@ export class ValueValidator {
         return validateType<ConfigObject>("object", value, fieldPath);
     }
 
-    static validateArray<T>(value: unknown, fieldPath: string, elementValidator?: (element: unknown, elementFieldName: string) => T): T[] {
+    static validateArray<T>(value: unknown, fieldPath: string, elementValidator?: (element: unknown, elementFieldPath: string) => T): T[] {
         if (!Array.isArray(value)) {
             throw new Error(getMessage('ConfigValueMustBeOfType', fieldPath, 'array', getDataType(value)));
         }
@@ -264,4 +305,17 @@ function validateAtLeastOnePathExists(paths: string[], fieldPath: string): strin
 
 function getDataType(value: unknown): string {
     return value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
+}
+
+export function getValueUsingCaseInsensitiveKey(obj: ConfigObject, key: string): ConfigValue {
+    if (key in obj) {
+        return obj[key];
+    }
+    key = key.toLowerCase();
+    for (const actualKey of Object.keys(obj)) {
+        if (key == actualKey.toLowerCase()) {
+            return obj[actualKey];
+        }
+    }
+    return null;
 }

--- a/packages/code-analyzer-engine-api/src/config.ts
+++ b/packages/code-analyzer-engine-api/src/config.ts
@@ -44,7 +44,7 @@ export class ConfigValueExtractor {
     private readonly configObj: ConfigObject;
     private readonly fieldPathRoot: string;
     private readonly configRoot: string;
-    private hiddenKeys: string[] = [];
+    private keysThatBypassValidation: string[] = [];
 
     constructor(configObject: ConfigObject, fieldPathRoot: string = '', configRoot: string = process.cwd()) {
         this.configObj = configObject;
@@ -52,8 +52,8 @@ export class ConfigValueExtractor {
         this.configRoot = configRoot;
     }
 
-    _addHiddenKeys(hiddenKeys: string[]) {
-        this.hiddenKeys = this.hiddenKeys.concat(hiddenKeys);
+    addKeysThatBypassValidation(keysThatBypassValidation: string[]) {
+        this.keysThatBypassValidation = this.keysThatBypassValidation.concat(keysThatBypassValidation);
     }
 
     getObject(): ConfigObject {
@@ -68,11 +68,11 @@ export class ConfigValueExtractor {
         return this.configRoot;
     }
 
-    validateOnlyContainsKeys(keys: string[]) {
+    validateContainsOnlySpecifiedKeys(keys: string[]) {
         const actualKeys: string[] = this.getKeys();
         const lowercasePublicKeys: string[] = keys.map(k => k.toLowerCase());
         for (const key of actualKeys) {
-            if (!lowercasePublicKeys.includes(key.toLowerCase()) && !this.hiddenKeys.includes(key)) {
+            if (!lowercasePublicKeys.includes(key.toLowerCase()) && !this.keysThatBypassValidation.includes(key)) {
                 throw new Error(getMessage('ConfigObjectContainsInvalidKey',
                     this.fieldPathRoot || '<TopLevel>', key, JSON.stringify(keys)))
             }

--- a/packages/code-analyzer-engine-api/src/index.ts
+++ b/packages/code-analyzer-engine-api/src/index.ts
@@ -4,6 +4,7 @@ export {
     ConfigObject,
     ConfigValue,
     ConfigValueExtractor,
+    getValueUsingCaseInsensitiveKey,
     ValueValidator
 } from "./config"
 

--- a/packages/code-analyzer-engine-api/src/messages.ts
+++ b/packages/code-analyzer-engine-api/src/messages.ts
@@ -34,6 +34,9 @@ export function getMessageFromCatalog(messageCatalog: MessageCatalog, msgId: str
 }
 
 export const SHARED_MESSAGE_CATALOG: MessageCatalog = {
+    ConfigObjectContainsInvalidKey:
+        `The '%s' configuration object contains an invalid key '%s'. Valid keys are: %s`,
+
     ConfigValueMustBeOfType:
         `The '%s' configuration value must be of type '%s' instead of type '%s'.`,
 

--- a/packages/code-analyzer-engine-api/test/config.test.ts
+++ b/packages/code-analyzer-engine-api/test/config.test.ts
@@ -234,23 +234,23 @@ describe("Tests for ConfigValueExtractor", () => {
         expect(extractor.getConfigRoot()).toEqual(__dirname);
     });
 
-    it("When validateOnlyContainsKeys is called on an object that has extra keys, then error", () => {
+    it("When validateContainsOnlySpecifiedKeys is called on an object that has extra keys, then error", () => {
         const topLevelExtractor: ConfigValueExtractor = new ConfigValueExtractor({a: 3, b: 2, c: 3}, '', __dirname);
-        expect(() => topLevelExtractor.validateOnlyContainsKeys(['a','C'])).toThrow(
+        expect(() => topLevelExtractor.validateContainsOnlySpecifiedKeys(['a','C'])).toThrow(
             Error(getMessage('ConfigObjectContainsInvalidKey','<TopLevel>', 'b', '["a","C"]')));
         const subExtractor: ConfigValueExtractor = new ConfigValueExtractor({d: 5, E: 6}, 'some.other[3]', __dirname);
-        subExtractor._addHiddenKeys(['hidden_keys']); // Sanity check that these don't show up in the error messages
-        expect(() => subExtractor.validateOnlyContainsKeys(['d'])).toThrow(
+        subExtractor.addKeysThatBypassValidation(['hidden_keys']); // Sanity check that these don't show up in the error messages
+        expect(() => subExtractor.validateContainsOnlySpecifiedKeys(['d'])).toThrow(
             Error(getMessage('ConfigObjectContainsInvalidKey','some.other[3]', 'E', '["d"]')));
     });
 
-    it("When validateOnlyContainsKeys is called on an object that has exact or less keys, then do not error", () => {
+    it("When validateContainsOnlySpecifiedKeys is called on an object that has exact or less keys, then do not error", () => {
         // Also sanity check that the keys are case-insensitive
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({a: 3, b: 2, C: 3}, '', __dirname);
-        extractor.validateOnlyContainsKeys(['A','b', 'c']); // Should not error
-        extractor.validateOnlyContainsKeys(['A','b', 'c','d','E']); // Should not error
-        extractor._addHiddenKeys(['C','d']);
-        extractor.validateOnlyContainsKeys(['a','b']); // Should not error (hidden keys are for internal use only and should also be accepted)
+        extractor.validateContainsOnlySpecifiedKeys(['A','b', 'c']); // Should not error
+        extractor.validateContainsOnlySpecifiedKeys(['A','b', 'c','d','E']); // Should not error
+        extractor.addKeysThatBypassValidation(['C','d']);
+        extractor.validateContainsOnlySpecifiedKeys(['a','b']); // Should not error (hidden keys are for internal use only and should also be accepted)
     });
 
     it("When calling extractRequiredBoolean on a field that contains a boolean, then return value", () => {

--- a/packages/code-analyzer-engine-api/test/config.test.ts
+++ b/packages/code-analyzer-engine-api/test/config.test.ts
@@ -45,10 +45,10 @@ describe("Tests for ValueValidator", () => {
         expect(ValueValidator.validateSeverityLevel('high', 'someFieldName')).toEqual(SeverityLevel.High);
     });
 
-    it.each([[3],0,'Medium'])("When an invalid value is given to validateSeverityLevel, then error", (value) => {
+    it.each([[3],0,'Medium',undefined])("When an invalid value is given to validateSeverityLevel, then error", (value) => {
         expect(() =>  ValueValidator.validateSeverityLevel(value, 'someFieldName')).toThrow(
             getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigValueNotAValidSeverityLevel', 'someFieldName',
-                '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', JSON.stringify(value)));
+                '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', JSON.stringify(value) || 'undefined'));
     });
 
     it("When a value matches the regular expression provided to validateString, then the value is returned", () => {
@@ -234,6 +234,25 @@ describe("Tests for ConfigValueExtractor", () => {
         expect(extractor.getConfigRoot()).toEqual(__dirname);
     });
 
+    it("When validateOnlyContainsKeys is called on an object that has extra keys, then error", () => {
+        const topLevelExtractor: ConfigValueExtractor = new ConfigValueExtractor({a: 3, b: 2, c: 3}, '', __dirname);
+        expect(() => topLevelExtractor.validateOnlyContainsKeys(['a','C'])).toThrow(
+            Error(getMessage('ConfigObjectContainsInvalidKey','<TopLevel>', 'b', '["a","C"]')));
+        const subExtractor: ConfigValueExtractor = new ConfigValueExtractor({d: 5, E: 6}, 'some.other[3]', __dirname);
+        subExtractor._addHiddenKeys(['hidden_keys']); // Sanity check that these don't show up in the error messages
+        expect(() => subExtractor.validateOnlyContainsKeys(['d'])).toThrow(
+            Error(getMessage('ConfigObjectContainsInvalidKey','some.other[3]', 'E', '["d"]')));
+    });
+
+    it("When validateOnlyContainsKeys is called on an object that has exact or less keys, then do not error", () => {
+        // Also sanity check that the keys are case-insensitive
+        const extractor: ConfigValueExtractor = new ConfigValueExtractor({a: 3, b: 2, C: 3}, '', __dirname);
+        extractor.validateOnlyContainsKeys(['A','b', 'c']); // Should not error
+        extractor.validateOnlyContainsKeys(['A','b', 'c','d','E']); // Should not error
+        extractor._addHiddenKeys(['C','d']);
+        extractor.validateOnlyContainsKeys(['a','b']); // Should not error (hidden keys are for internal use only and should also be accepted)
+    });
+
     it("When calling extractRequiredBoolean on a field that contains a boolean, then return value", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: false}, 'engines.dummy');
         expect(extractor.extractRequiredBoolean('some_field')).toEqual(false);
@@ -242,7 +261,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredBoolean on a field is missing, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredBoolean('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'boolean', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'boolean', 'null'));
     });
 
     it("When calling extractRequiredBoolean on a non-boolean field, then error", () => {
@@ -259,7 +278,7 @@ describe("Tests for ConfigValueExtractor", () => {
 
     it("When calling extractBoolean on a field that is a boolean, then return in", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: true});
-        expect(extractor.extractBoolean('some_field')).toEqual(true);
+        expect(extractor.extractBoolean('some_Field')).toEqual(true); // Sanity check key match is case-insensitive
         expect(extractor.extractBoolean('some_field', false)).toEqual(true);
     });
 
@@ -280,7 +299,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredNumber on a field is missing, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredNumber('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'number', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'number', 'null'));
     });
 
     it("When calling extractRequiredNumber on a non-number field, then error", () => {
@@ -298,7 +317,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractNumber on a field that is a number, then return in", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: 5});
         expect(extractor.extractNumber('some_field')).toEqual(5);
-        expect(extractor.extractNumber('some_field', 1)).toEqual(5);
+        expect(extractor.extractNumber('soME_field', 1)).toEqual(5); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractNumber on a non-number field, then error", () => {
@@ -312,13 +331,13 @@ describe("Tests for ConfigValueExtractor", () => {
 
     it("When calling extractRequiredString on a field that contains a string, then return value", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: 'great'}, 'engines.dummy');
-        expect(extractor.extractRequiredString('some_field')).toEqual('great');
+        expect(extractor.extractRequiredString('some_fiEld')).toEqual('great'); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractRequiredString on a field is missing, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredString('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'string', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'string', 'null'));
     });
 
     it("When calling extractRequiredString on a non-number field, then error", () => {
@@ -372,14 +391,14 @@ describe("Tests for ConfigValueExtractor", () => {
 
     it("When calling extractRequiredSeverityLevel on a field that contains a valid string, then return value", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: 'INFO'}, 'engines.dummy');
-        expect(extractor.extractRequiredSeverityLevel('some_field')).toEqual(SeverityLevel.Info);
+        expect(extractor.extractRequiredSeverityLevel('some_fiEld')).toEqual(SeverityLevel.Info);
     });
 
     it("When calling extractRequiredSeverityLevel on a field is missing, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredSeverityLevel('some_field')).toThrow(
             getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigValueNotAValidSeverityLevel', 'engines.dummy.some_field',
-                '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', 'undefined'));
+                '["Critical","High","Moderate","Low","Info",1,2,3,4,5]', 'null'));
     });
 
     it("When calling extractRequiredSeverityLevel on a field that contains a invalid value, then error", () => {
@@ -391,7 +410,7 @@ describe("Tests for ConfigValueExtractor", () => {
 
     it("When calling extractSeverityLevel on a field that contains a valid number, then return value", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: 4}, 'engines.dummy');
-        expect(extractor.extractSeverityLevel('some_field')).toEqual(SeverityLevel.Low);
+        expect(extractor.extractSeverityLevel('some_fielD')).toEqual(SeverityLevel.Low); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractSeverityLevel on a non-string non-number, then error", () => {
@@ -415,7 +434,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredObject on a field is missing, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredObject('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'object', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'object', 'null'));
     });
 
     it("When calling extractRequiredObject on a non-object field, then error", () => {
@@ -433,7 +452,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractObject on a field that is an object, then return in", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: {hello: 'world'}});
         expect(extractor.extractObject('some_field')).toEqual({hello: 'world'});
-        expect(extractor.extractObject('some_field', {})).toEqual({hello: 'world'});
+        expect(extractor.extractObject('Some_field', {})).toEqual({hello: 'world'}); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractObject on a non-object field, then error", () => {
@@ -448,14 +467,14 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredArray with a number element validator on field that is not defined, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredArray('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'array', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'array', 'null'));
         expect(() => extractor.extractRequiredArray('some_field', ValueValidator.validateNumber)).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'array', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'array', 'null'));
     });
 
     it("When calling extractRequiredArray with no validator on a heterogeneous array, then return it", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: ['hello', 3]});
-        expect(extractor.extractRequiredArray('some_field')).toEqual(['hello', 3]);
+        expect(extractor.extractRequiredArray('some_fielD')).toEqual(['hello', 3]); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractRequiredArray with a number element validator on a field that is an number array, then return it", () => {
@@ -486,7 +505,7 @@ describe("Tests for ConfigValueExtractor", () => {
 
     it("When calling extractArray with a string element validator on a field that is an string array, then return it", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: ['hello', 'world']});
-        expect(extractor.extractArray('some_field', ValueValidator.validateString)).toEqual(['hello', 'world']);
+        expect(extractor.extractArray('sOme_field', ValueValidator.validateString)).toEqual(['hello', 'world']); // Sanity check key match is case-insensitive
         expect(extractor.extractArray('some_field', ValueValidator.validateString, [])).toEqual(['hello', 'world']);
     });
 
@@ -508,7 +527,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredFile on a field that does not exist, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({});
         expect(() => extractor.extractRequiredFile('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'some_field', 'string', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'some_field', 'string', 'null'));
     });
 
     it("When calling extractRequiredFile on valid file, then return it as absolute", () => {
@@ -516,7 +535,7 @@ describe("Tests for ConfigValueExtractor", () => {
             some_field: 'test-data\\sampleWorkspace\\someFile.txt'
         }, 'engines.dummy', __dirname);
         const expectedFile: string = path.resolve(__dirname, 'test-data', 'sampleWorkspace', 'someFile.txt');
-        expect(extractor.extractRequiredFile('some_field')).toEqual(expectedFile);
+        expect(extractor.extractRequiredFile('some_fieLd')).toEqual(expectedFile); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractRequiredFile on a field that is not a string, then error", () => {
@@ -578,7 +597,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredFolder on a field that does not exist, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredFolder('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'string', 'undefined'));
+            getMessage('ConfigValueMustBeOfType', 'engines.dummy.some_field', 'string', 'null'));
     });
 
     it("When calling extractRequiredFolder on valid relative folder, then return it as absolute", () => {
@@ -636,7 +655,7 @@ describe("Tests for ConfigValueExtractor", () => {
         }, 'engines.dummy', __dirname);
         const expectedFolder: string = path.resolve(__dirname, 'test-data', 'sampleWorkspace');
         expect(extractor.extractFolder('some_field')).toEqual(expectedFolder);
-        expect(extractor.extractFolder('some_field', 'someDefault')).toEqual(expectedFolder);
+        expect(extractor.extractFolder('some_fiEld', 'someDefault')).toEqual(expectedFolder); // Sanity check key match is case-insensitive
     });
 
     it("When calling extractFolder on valid absolute folder, then return it as absolute", () => {
@@ -678,7 +697,7 @@ describe("Tests for ConfigValueExtractor", () => {
     it("When calling extractRequiredObjectAsExtractor on a field that does not exist, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredObjectAsExtractor('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType','engines.dummy.some_field', 'object', 'undefined'));
+            getMessage('ConfigValueMustBeOfType','engines.dummy.some_field', 'object', 'null'));
     });
 
     it("When calling extractRequiredObjectAsExtractor on a field that is not an object, then error", () => {
@@ -714,16 +733,16 @@ describe("Tests for ConfigValueExtractor", () => {
     });
 
     it("When calling extractObjectAsExtractor on a field that is an object, then return the extractor for it", () => {
-        const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: {another_field: 3}}, 'engines.dummy');
-        const subValueExtractor: ConfigValueExtractor = extractor.extractObjectAsExtractor('some_field', {});
+        const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: {another_fielD: 3}}, 'engines.dummy');
+        const subValueExtractor: ConfigValueExtractor = extractor.extractObjectAsExtractor('some_field', {}); // Sanity check key match is case-insensitive
         expect(subValueExtractor.getFieldPath()).toEqual('engines.dummy.some_field');
-        expect(subValueExtractor.getObject()).toEqual({another_field: 3});
+        expect(subValueExtractor.getObject()).toEqual({another_fielD: 3});
     });
 
     it("When calling extractRequiredObjectArrayAsExtractorArray on a field that does not exist, then error", () => {
         const extractor: ConfigValueExtractor = new ConfigValueExtractor({}, 'engines.dummy');
         expect(() => extractor.extractRequiredObjectArrayAsExtractorArray('some_field')).toThrow(
-            getMessage('ConfigValueMustBeOfType','engines.dummy.some_field', 'array', 'undefined'));
+            getMessage('ConfigValueMustBeOfType','engines.dummy.some_field', 'array', 'null'));
     });
 
     it("When calling extractRequiredObjectArrayAsExtractorArray on a field that is not an array, then error", () => {
@@ -776,8 +795,8 @@ describe("Tests for ConfigValueExtractor", () => {
     });
 
     it("When calling extractObjectArrayAsExtractorArray on a field that is an array of objects, then return the extractor for it", () => {
-        const extractor: ConfigValueExtractor = new ConfigValueExtractor({some_field: [{a: 1}, {b: 2}, {c: 3}]}, 'engines.dummy1.dummy2[5]');
-        const subValueExtractors: ConfigValueExtractor[] = extractor.extractObjectArrayAsExtractorArray('some_field');
+        const extractor: ConfigValueExtractor = new ConfigValueExtractor({somE_field: [{a: 1}, {b: 2}, {c: 3}]}, 'engines.dummy1.dummy2[5]');
+        const subValueExtractors: ConfigValueExtractor[] = extractor.extractObjectArrayAsExtractorArray('some_field'); // Sanity check key match is case-insensitive
         expect(subValueExtractors).toHaveLength(3);
         expect(subValueExtractors[0].getFieldPath()).toEqual('engines.dummy1.dummy2[5].some_field[0]');
         expect(subValueExtractors[0].getObject()).toEqual({a: 1});
@@ -792,7 +811,7 @@ describe("Tests for ConfigValueExtractor", () => {
         expect(extractor.hasValueDefinedFor('a')).toEqual(true);
         expect(extractor.hasValueDefinedFor('b')).toEqual(false);
         expect(extractor.hasValueDefinedFor('c')).toEqual(true);
-        expect(extractor.hasValueDefinedFor('d')).toEqual(true);
+        expect(extractor.hasValueDefinedFor('D')).toEqual(true); // Sanity check key match is case-insensitive
         expect(extractor.hasValueDefinedFor('e')).toEqual(true);
         expect(extractor.hasValueDefinedFor('f')).toEqual(false);
     });

--- a/packages/code-analyzer-eslint-engine/package.json
+++ b/packages/code-analyzer-eslint-engine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/code-analyzer-eslint-engine",
     "description": "Plugin package that adds 'eslint' as an engine into Salesforce Code Analyzer",
-    "version": "0.15.1-SNAPSHOT",
+    "version": "0.16.0-SNAPSHOT",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -17,7 +17,7 @@
         "@babel/eslint-parser": "^7.25.9",
         "@eslint/js": "^8.57.1",
         "@lwc/eslint-plugin-lwc": "^1.8.2",
-        "@salesforce/code-analyzer-engine-api": "0.15.0",
+        "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT",
         "@salesforce/eslint-config-lwc": "^3.6.0",
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
         "@types/eslint": "^8.56.10",

--- a/packages/code-analyzer-eslint-engine/src/config.ts
+++ b/packages/code-analyzer-eslint-engine/src/config.ts
@@ -112,7 +112,7 @@ export const LEGACY_ESLINT_IGNORE_FILE: string = '.eslintignore';
 
 
 export function validateAndNormalizeConfig(configValueExtractor: ConfigValueExtractor): ESLintEngineConfig {
-    configValueExtractor.validateOnlyContainsKeys(['eslint_config_file', 'eslint_ignore_file',
+    configValueExtractor.validateContainsOnlySpecifiedKeys(['eslint_config_file', 'eslint_ignore_file',
         'auto_discover_eslint_config', 'disable_javascript_base_config', 'disable_lwc_base_config',
         'disable_typescript_base_config', 'file_extensions']);
 

--- a/packages/code-analyzer-eslint-engine/src/config.ts
+++ b/packages/code-analyzer-eslint-engine/src/config.ts
@@ -112,6 +112,10 @@ export const LEGACY_ESLINT_IGNORE_FILE: string = '.eslintignore';
 
 
 export function validateAndNormalizeConfig(configValueExtractor: ConfigValueExtractor): ESLintEngineConfig {
+    configValueExtractor.validateOnlyContainsKeys(['eslint_config_file', 'eslint_ignore_file',
+        'auto_discover_eslint_config', 'disable_javascript_base_config', 'disable_lwc_base_config',
+        'disable_typescript_base_config', 'file_extensions']);
+
     const eslintConfigValueExtractor: ESLintEngineConfigValueExtractor = new ESLintEngineConfigValueExtractor(configValueExtractor);
     return {
         config_root: configValueExtractor.getConfigRoot(), // INTERNAL USE ONLY

--- a/packages/code-analyzer-eslint-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-eslint-engine/test/plugin.test.ts
@@ -43,9 +43,13 @@ describe('Tests for the ESLintEnginePlugin', () => {
         expect(await callCreateEngineConfig(plugin, {})).toEqual(DEFAULT_CONFIG);
     });
 
-    it('When value we do not care about is passed to createEngineConfig, then we ignore it', async () => {
+    it('When createEngineConfig is called with an object containing an invalid key, then we error', async () => {
         const userProvidedOverrides: ConfigObject = {dummy: 3};
-        expect(await callCreateEngineConfig(plugin, userProvidedOverrides)).toEqual(DEFAULT_CONFIG);
+        await expect(callCreateEngineConfig(plugin, userProvidedOverrides)).rejects.toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.eslint', 'dummy',
+                '["eslint_config_file","eslint_ignore_file","auto_discover_eslint_config",' +
+                '"disable_javascript_base_config","disable_lwc_base_config","disable_typescript_base_config",' +
+                '"file_extensions"]'));
     });
 
     it('When a valid eslint_config_file is passed to createEngineConfig, then it is set on the config', async () => {

--- a/packages/code-analyzer-flowtest-engine/package.json
+++ b/packages/code-analyzer-flowtest-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-flowtest-engine",
   "description": "Plugin package that adds 'flowtest' as an engine into Salesforce Code Analyzer",
-  "version": "0.15.0",
+  "version": "0.16.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.15.0",
+    "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.5.8",
     "@types/tmp": "^0.2.6",

--- a/packages/code-analyzer-flowtest-engine/src/config.ts
+++ b/packages/code-analyzer-flowtest-engine/src/config.ts
@@ -28,7 +28,7 @@ export const FLOWTEST_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {
 
 export async function validateAndNormalizeConfig(configValueExtractor: ConfigValueExtractor,
                                                  pythonVersionIdentifier: PythonVersionIdentifier): Promise<FlowTestConfig> {
-    configValueExtractor.validateOnlyContainsKeys(['python_command']);
+    configValueExtractor.validateContainsOnlySpecifiedKeys(['python_command']);
     const valueExtractor: FlowTestEngineConfigValueExtractor = new FlowTestEngineConfigValueExtractor(
         configValueExtractor, pythonVersionIdentifier);
     return {

--- a/packages/code-analyzer-flowtest-engine/src/config.ts
+++ b/packages/code-analyzer-flowtest-engine/src/config.ts
@@ -28,6 +28,7 @@ export const FLOWTEST_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {
 
 export async function validateAndNormalizeConfig(configValueExtractor: ConfigValueExtractor,
                                                  pythonVersionIdentifier: PythonVersionIdentifier): Promise<FlowTestConfig> {
+    configValueExtractor.validateOnlyContainsKeys(['python_command']);
     const valueExtractor: FlowTestEngineConfigValueExtractor = new FlowTestEngineConfigValueExtractor(
         configValueExtractor, pythonVersionIdentifier);
     return {

--- a/packages/code-analyzer-flowtest-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-flowtest-engine/test/plugin.test.ts
@@ -1,4 +1,11 @@
-import {ConfigObject, ConfigValueExtractor, Engine, EnginePluginV1} from "@salesforce/code-analyzer-engine-api";
+import {
+    ConfigObject,
+    ConfigValueExtractor,
+    Engine,
+    EnginePluginV1,
+    getMessageFromCatalog,
+    SHARED_MESSAGE_CATALOG
+} from "@salesforce/code-analyzer-engine-api";
 import {FlowTestEnginePlugin} from "../src";
 import {FlowTestEngine} from "../src/engine";
 import {getMessage} from "../src/messages";
@@ -43,6 +50,13 @@ describe('Tests for the FlowTestEnginePlugin', () => {
         const userProvidedOverrides: ConfigObject = {};
         await expect(callCreateEngineConfig(plugin, userProvidedOverrides)).rejects.toThrow(getMessage('CouldNotLocatePython',
             '3.10.0', '["python3","python"]', 'engines.flowtest.python_command', FlowTestEngine.NAME, FlowTestEngine.NAME));
+    });
+
+    it('When createEngineConfig is called an object that contains an invalid key, then error', async () => {
+        const plugin: EnginePluginV1 = new FlowTestEnginePlugin(new StubPythonVersionIdentifier());
+        await expect(callCreateEngineConfig(plugin, {unknownField: 3})).rejects.toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.flowtest', 'unknownField',
+                '["python_command"]'));
     });
 
     it('When createEngineConfig is called with user provided python and it is valid, then the command is in the config', async () => {

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/code-analyzer-pmd-engine",
     "description": "Plugin package that adds 'pmd' and 'cpd' as engines into Salesforce Code Analyzer",
-    "version": "0.15.1-SNAPSHOT",
+    "version": "0.16.0-SNAPSHOT",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -14,7 +14,7 @@
     "types": "dist/index.d.ts",
     "dependencies": {
       "@types/node": "^20.0.0",
-      "@salesforce/code-analyzer-engine-api": "0.15.0",
+      "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT",
       "@types/tmp": "^0.2.6",
       "tmp": "^0.2.3",
       "@types/semver": "^7.5.8",

--- a/packages/code-analyzer-pmd-engine/src/config.ts
+++ b/packages/code-analyzer-pmd-engine/src/config.ts
@@ -138,8 +138,8 @@ export const CPD_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {
 
 export async function validateAndNormalizePmdConfig(configValueExtractor: ConfigValueExtractor,
                                                     javaVersionIdentifier: JavaVersionIdentifier): Promise<PmdEngineConfig> {
-    configValueExtractor._addHiddenKeys(['rule_languages']);
-    configValueExtractor.validateOnlyContainsKeys(['java_command', 'java_classpath_entries', 'custom_rulesets']);
+    configValueExtractor.addKeysThatBypassValidation(['rule_languages']); // because rule_languages is currently hidden
+    configValueExtractor.validateContainsOnlySpecifiedKeys(['java_command', 'java_classpath_entries', 'custom_rulesets']);
 
     const pmdConfigValueExtractor: PmdConfigValueExtractor = new PmdConfigValueExtractor(configValueExtractor,
         javaVersionIdentifier);
@@ -155,8 +155,8 @@ export async function validateAndNormalizePmdConfig(configValueExtractor: Config
 
 export async function validateAndNormalizeCpdConfig(configValueExtractor: ConfigValueExtractor,
                                                     javaVersionIdentifier: JavaVersionIdentifier): Promise<CpdEngineConfig> {
-    configValueExtractor._addHiddenKeys(['rule_languages']);
-    configValueExtractor.validateOnlyContainsKeys(['java_command', 'minimum_tokens', 'skip_duplicate_files']);
+    configValueExtractor.addKeysThatBypassValidation(['rule_languages']); // because rule_languages is currently hidden
+    configValueExtractor.validateContainsOnlySpecifiedKeys(['java_command', 'minimum_tokens', 'skip_duplicate_files']);
 
     const cpdConfigValueExtractor: CpdConfigValueExtractor = new CpdConfigValueExtractor(configValueExtractor,
         javaVersionIdentifier);
@@ -345,7 +345,7 @@ class CpdConfigValueExtractor extends SharedConfigValueExtractor {
         const minimumTokensExtractor: ConfigValueExtractor = this.configValueExtractor.extractObjectAsExtractor(
             'minimum_tokens', DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens);
 
-        minimumTokensExtractor.validateOnlyContainsKeys(CPD_AVAILABLE_LANGUAGES);
+        minimumTokensExtractor.validateContainsOnlySpecifiedKeys(CPD_AVAILABLE_LANGUAGES);
 
         const minimumTokensMap: Record<Language, number> = {... DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens}; // Start with copy
         for (const language of CPD_AVAILABLE_LANGUAGES) {

--- a/packages/code-analyzer-pmd-engine/src/config.ts
+++ b/packages/code-analyzer-pmd-engine/src/config.ts
@@ -138,6 +138,9 @@ export const CPD_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {
 
 export async function validateAndNormalizePmdConfig(configValueExtractor: ConfigValueExtractor,
                                                     javaVersionIdentifier: JavaVersionIdentifier): Promise<PmdEngineConfig> {
+    configValueExtractor._addHiddenKeys(['rule_languages']);
+    configValueExtractor.validateOnlyContainsKeys(['java_command', 'java_classpath_entries', 'custom_rulesets']);
+
     const pmdConfigValueExtractor: PmdConfigValueExtractor = new PmdConfigValueExtractor(configValueExtractor,
         javaVersionIdentifier);
 
@@ -152,6 +155,9 @@ export async function validateAndNormalizePmdConfig(configValueExtractor: Config
 
 export async function validateAndNormalizeCpdConfig(configValueExtractor: ConfigValueExtractor,
                                                     javaVersionIdentifier: JavaVersionIdentifier): Promise<CpdEngineConfig> {
+    configValueExtractor._addHiddenKeys(['rule_languages']);
+    configValueExtractor.validateOnlyContainsKeys(['java_command', 'minimum_tokens', 'skip_duplicate_files']);
+
     const cpdConfigValueExtractor: CpdConfigValueExtractor = new CpdConfigValueExtractor(configValueExtractor,
         javaVersionIdentifier);
 
@@ -339,29 +345,16 @@ class CpdConfigValueExtractor extends SharedConfigValueExtractor {
         const minimumTokensExtractor: ConfigValueExtractor = this.configValueExtractor.extractObjectAsExtractor(
             'minimum_tokens', DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens);
 
-        // Start with a copy will all the default values
-        const minimumTokensMap: Record<Language, number> = {...DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens};
+        minimumTokensExtractor.validateOnlyContainsKeys(CPD_AVAILABLE_LANGUAGES);
 
-        // And override the default values with user provided values for each language found
-        for (const key of minimumTokensExtractor.getKeys()) {
-            let language: string = key.toLowerCase();
-            if (language === 'ecmascript') {
-                // Provide support for 'ecmascript' which is a supported alias of 'javascript'
-                language = 'javascript';
-            }
-
-            if (!(CPD_AVAILABLE_LANGUAGES as string[]).includes(language)) {
-                throw new Error(getMessage('InvalidFieldKeyForObject',
-                    this.configValueExtractor.getFieldPath('minimum_tokens'), key, toAvailableLanguagesText(CPD_AVAILABLE_LANGUAGES)));
-            }
-
-            const minimumTokensValue: number = minimumTokensExtractor.extractRequiredNumber(key);
+        const minimumTokensMap: Record<Language, number> = {... DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens}; // Start with copy
+        for (const language of CPD_AVAILABLE_LANGUAGES) {
+            const minimumTokensValue: number = minimumTokensExtractor.extractNumber(language, DEFAULT_CPD_ENGINE_CONFIG.minimum_tokens[language])!;
             if (minimumTokensValue <= 0 || Math.floor(minimumTokensValue) != minimumTokensValue) {
-                throw new Error(getMessage('InvalidPositiveInteger', minimumTokensExtractor.getFieldPath(key)));
+                throw new Error(getMessage('InvalidPositiveInteger', minimumTokensExtractor.getFieldPath(language)));
             }
-            minimumTokensMap[language as Language] = minimumTokensValue;
+            minimumTokensMap[language] = minimumTokensValue;
         }
-
         return minimumTokensMap;
     }
 

--- a/packages/code-analyzer-pmd-engine/src/messages.ts
+++ b/packages/code-analyzer-pmd-engine/src/messages.ts
@@ -89,10 +89,7 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
         `Duplicate code detected for language '%s'. Found %d code locations containing the same block of code consisting of %d tokens across %d lines.`,
 
     InvalidPositiveInteger:
-        `The '%s' configuration value is invalid. The value must be a positive integer.`,
-
-    InvalidFieldKeyForObject:
-        `The '%s' configuration value is invalid. The value contained an invalid key '%s'. Valid keys for this object are: %s`
+        `The '%s' configuration value is invalid. The value must be a positive integer.`
 }
 
 /**

--- a/packages/code-analyzer-pmd-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-pmd-engine/test/plugin.test.ts
@@ -44,6 +44,13 @@ describe('Tests for the PmdCpdEnginesPlugin', () => {
         expect(() => plugin.describeEngineConfig('oops')).toThrow(getMessage('UnsupportedEngineName', 'oops'));
     });
 
+    it(`When createEngineConfig for 'cpd' is given an object with an unknown field, then error`, async () => {
+        const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor({unknownField: 3}, 'engines.cpd');
+        await expect(plugin.createEngineConfig('cpd', configValueExtractor)).rejects.toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.cpd', 'unknownField',
+                '["java_command","minimum_tokens","skip_duplicate_files"]'));
+    });
+
     it(`When createEngineConfig for 'cpd' is given an empty raw config, then the correct defaults are returned (assuming java version is correct on machine)`, async () => {
         // This test assumes that all environments that run this test will have JAVA v11+ installed and either has
         // * the JAVA_HOME environment variable points to the home folder of this java command
@@ -63,6 +70,13 @@ describe('Tests for the PmdCpdEnginesPlugin', () => {
             },
             skip_duplicate_files: false
         });
+    });
+
+    it(`When createEngineConfig for 'pmd' is given an object with an unknown field, then error`, async () => {
+        const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor({unknownField: 3}, 'engines.pmd');
+        await expect(plugin.createEngineConfig('pmd', configValueExtractor)).rejects.toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.pmd', 'unknownField',
+                '["java_command","java_classpath_entries","custom_rulesets"]'));
     });
 
     it(`When createEngineConfig for 'pmd' is given an empty raw config, then the correct defaults are returned (assuming java version is correct on machine)`, async () => {
@@ -316,8 +330,8 @@ describe('Tests for the PmdCpdEnginesPlugin', () => {
         const rawConfig: ConfigObject = {minimum_tokens: {apex: 100, oops: 100}};
         const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.cpd');
         await expect(plugin.createEngineConfig('cpd', configValueExtractor)).rejects.toThrow(
-            getMessage('InvalidFieldKeyForObject', 'engines.cpd.minimum_tokens', 'oops',
-                "'apex', 'html', 'javascript' (or 'ecmascript'), 'typescript', 'visualforce', 'xml'"));
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.cpd.minimum_tokens',
+                'oops', '["apex","html","javascript","typescript","visualforce","xml"]'));
     });
 
     it.each([-5,0,2.5])(`When createEngineConfig for 'cpd' is given a minumum_tokens.xml number %s that is not a positive integer, then error`, async (invalidValue) => {
@@ -328,7 +342,7 @@ describe('Tests for the PmdCpdEnginesPlugin', () => {
     });
 
     it(`When createEngineConfig for 'cpd' is given a valid minimum_tokens value, then it is used`, async() => {
-        const rawConfig: ConfigObject = {minimum_tokens: {apex: 18, xml: 30, ecmascript: 25}}; // Also test that ecmascript can be used as an alias of javascript
+        const rawConfig: ConfigObject = {minimum_toKens: {aPEx: 18, xml: 30, javaSCRipt: 25}}; // Also test that the names are case-insensitive
         const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.cpd');
         const resolvedConfig: ConfigObject = await plugin.createEngineConfig('cpd', configValueExtractor);
         expect(resolvedConfig['minimum_tokens']).toEqual({

--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/code-analyzer-regex-engine",
     "description": "Plugin package that adds 'regex' as an engine into Salesforce Code Analyzer",
-    "version": "0.15.0",
+    "version": "0.16.0-SNAPSHOT",
     "author": "The Salesforce Code Analyzer Team",
     "license": "BSD-3-Clause",
     "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.15.0",
+        "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "isbinaryfile": "^5.0.4"
     },

--- a/packages/code-analyzer-regex-engine/src/config.ts
+++ b/packages/code-analyzer-regex-engine/src/config.ts
@@ -63,7 +63,7 @@ export const REGEX_STRING_PATTERN: RegExp = /^\/(.*)\/(.*)$/;
 export const DEFAULT_SEVERITY_LEVEL: SeverityLevel = SeverityLevel.Moderate;
 
 export function validateAndNormalizeConfig(valueExtractor: ConfigValueExtractor): RegexEngineConfig {
-    valueExtractor.validateOnlyContainsKeys(['custom_rules']);
+    valueExtractor.validateContainsOnlySpecifiedKeys(['custom_rules']);
     const customRulesExtractor: ConfigValueExtractor = valueExtractor.extractObjectAsExtractor('custom_rules');
     const customRules: RegexRules = {};
     for (const ruleName of customRulesExtractor.getKeys()) {

--- a/packages/code-analyzer-regex-engine/src/config.ts
+++ b/packages/code-analyzer-regex-engine/src/config.ts
@@ -63,6 +63,7 @@ export const REGEX_STRING_PATTERN: RegExp = /^\/(.*)\/(.*)$/;
 export const DEFAULT_SEVERITY_LEVEL: SeverityLevel = SeverityLevel.Moderate;
 
 export function validateAndNormalizeConfig(valueExtractor: ConfigValueExtractor): RegexEngineConfig {
+    valueExtractor.validateOnlyContainsKeys(['custom_rules']);
     const customRulesExtractor: ConfigValueExtractor = valueExtractor.extractObjectAsExtractor('custom_rules');
     const customRules: RegexRules = {};
     for (const ruleName of customRulesExtractor.getKeys()) {

--- a/packages/code-analyzer-regex-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-regex-engine/test/plugin.test.ts
@@ -140,6 +140,13 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
         expect(engine._getRegexRules()).toEqual(expRegexRules);
     });
 
+    it('If createEngineConfig is given an object with an unknown field, then error', async () => {
+        const valueExtractor: ConfigValueExtractor = new ConfigValueExtractor({unknownField: 3}, 'engines.regex');
+        await expect(plugin.createEngineConfig('regex', valueExtractor)).rejects.toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.regex',
+                'unknownField', '["custom_rules"]'));
+    });
+
     it('If custom_rules is given as an array instead of an object, emit appropriate error', async () => {
         const rawConfig: ConfigObject = {
             custom_rules: [
@@ -283,7 +290,7 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
         const valueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.regex');
         await expect(plugin.createEngineConfig("regex", valueExtractor)).rejects.toThrow(
             getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigValueMustBeOfType',
-                'engines.regex.custom_rules.NoTodos.regex', 'string', 'undefined'));
+                'engines.regex.custom_rules.NoTodos.regex', 'string', 'null'));
     });
 
     it("If rule name is empty, ensure proper error is emitted", async () => {
@@ -345,7 +352,7 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
         };
         const valueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.regex');
         await expect(plugin.createEngineConfig("regex", valueExtractor)).rejects.toThrow(
-            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigValueMustBeOfType', 'engines.regex.custom_rules.NoTodos.description', 'string', 'undefined'));
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigValueMustBeOfType', 'engines.regex.custom_rules.NoTodos.description', 'string', 'null'));
     });
 
     it("If file_extensions are not a string array, ensure proper error is emitted", async () => {

--- a/packages/code-analyzer-retirejs-engine/package.json
+++ b/packages/code-analyzer-retirejs-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-retirejs-engine",
   "description": "Plugin package that adds 'retire-js' as an engine into Salesforce Code Analyzer",
-  "version": "0.15.0",
+  "version": "0.16.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.15.0",
+    "@salesforce/code-analyzer-engine-api": "0.16.0-SNAPSHOT",
     "@types/node": "^20.0.0",
     "@types/tmp": "^0.2.6",
     "isbinaryfile": "^5.0.4",

--- a/packages/code-analyzer-retirejs-engine/src/engine.ts
+++ b/packages/code-analyzer-retirejs-engine/src/engine.ts
@@ -1,9 +1,7 @@
 import {
     COMMON_TAGS,
-    ConfigObject,
     DescribeOptions,
     Engine,
-    EnginePluginV1,
     EngineRunResults,
     EventType,
     LogEvent,
@@ -44,19 +42,6 @@ const SeverityMap: Map<RetireJsSeverity, SeverityLevel> = new Map([
     [RetireJsSeverity.Medium, SeverityLevel.Moderate],
     [RetireJsSeverity.Low, SeverityLevel.Low]
 ]);
-
-export class RetireJsEnginePlugin extends EnginePluginV1 {
-    getAvailableEngineNames(): string[] {
-        return [RetireJsEngine.NAME];
-    }
-
-    async createEngine(engineName: string, _config: ConfigObject): Promise<Engine> {
-        if (engineName === RetireJsEngine.NAME) {
-            return new RetireJsEngine();
-        }
-        throw new Error(getMessage('CantCreateEngineWithUnknownEngineName', engineName));
-    }
-}
 
 export class RetireJsEngine extends Engine {
     static readonly NAME = "retire-js";

--- a/packages/code-analyzer-retirejs-engine/src/index.ts
+++ b/packages/code-analyzer-retirejs-engine/src/index.ts
@@ -1,4 +1,4 @@
-import {RetireJsEnginePlugin} from "./engine";
+import {RetireJsEnginePlugin} from "./plugin";
 import {EnginePlugin} from "@salesforce/code-analyzer-engine-api";
 
 function createEnginePlugin(): EnginePlugin {

--- a/packages/code-analyzer-retirejs-engine/src/messages.ts
+++ b/packages/code-analyzer-retirejs-engine/src/messages.ts
@@ -1,6 +1,6 @@
 const messageCatalog : { [key: string]: string } = {
-    CantCreateEngineWithUnknownEngineName:
-        `The RetireJsEnginePlugin does not support creating an engine with name '%s'.`,
+    UnsupportedEngineName:
+        `The RetireJsEnginePlugin does not support an engine with name '%s'.`,
 
     RetireJsRuleDescription:
         `Identifies JavaScript libraries with known vulnerabilities of %s severity.`,

--- a/packages/code-analyzer-retirejs-engine/src/plugin.ts
+++ b/packages/code-analyzer-retirejs-engine/src/plugin.ts
@@ -14,7 +14,7 @@ export class RetireJsEnginePlugin extends EnginePluginV1 {
 
     async createEngineConfig(engineName: string, configValueExtractor: ConfigValueExtractor): Promise<ConfigObject> {
         validateEngineName(engineName);
-        configValueExtractor.validateOnlyContainsKeys([]);
+        configValueExtractor.validateContainsOnlySpecifiedKeys([]);
         return {};
     }
 }

--- a/packages/code-analyzer-retirejs-engine/src/plugin.ts
+++ b/packages/code-analyzer-retirejs-engine/src/plugin.ts
@@ -1,0 +1,26 @@
+import {ConfigObject, ConfigValueExtractor, Engine, EnginePluginV1} from "@salesforce/code-analyzer-engine-api";
+import {getMessage} from "./messages";
+import {RetireJsEngine} from "./engine";
+
+export class RetireJsEnginePlugin extends EnginePluginV1 {
+    getAvailableEngineNames(): string[] {
+        return [RetireJsEngine.NAME];
+    }
+
+    async createEngine(engineName: string, _config: ConfigObject): Promise<Engine> {
+        validateEngineName(engineName);
+        return new RetireJsEngine();
+    }
+
+    async createEngineConfig(engineName: string, configValueExtractor: ConfigValueExtractor): Promise<ConfigObject> {
+        validateEngineName(engineName);
+        configValueExtractor.validateOnlyContainsKeys([]);
+        return {};
+    }
+}
+
+function validateEngineName(engineName: string): void {
+    if (engineName !== RetireJsEngine.NAME) {
+        throw new Error(getMessage('UnsupportedEngineName', engineName));
+    }
+}

--- a/packages/code-analyzer-retirejs-engine/test/engine.test.ts
+++ b/packages/code-analyzer-retirejs-engine/test/engine.test.ts
@@ -83,26 +83,6 @@ const DUMMY_WORKSPACE: Workspace = new Workspace([path.resolve(__dirname,'test-d
 const DUMMY_DESCRIBE_OPTIONS: DescribeOptions = {workspace: DUMMY_WORKSPACE}
 const DUMMY_RUN_OPTIONS: RunOptions = {workspace: DUMMY_WORKSPACE}
 
-describe('Tests for the RetireJsEnginePlugin', () => {
-    let plugin: EnginePluginV1;
-    beforeAll(() => {
-        plugin = new RetireJsEnginePlugin();
-    });
-
-    it('When the getAvailableEngineNames method is called then only retire-js is returned', () => {
-        expect(plugin.getAvailableEngineNames()).toEqual(['retire-js']);
-    });
-
-    it('When createEngine is passed retire-js then an RetireJsEngine instance is returned', async () => {
-        expect(await plugin.createEngine('retire-js', {})).toBeInstanceOf(RetireJsEngine);
-    });
-
-    it('When createEngine is passed anything else then an error is thrown', async () => {
-        await expect(plugin.createEngine('oops', {})).rejects.toThrow(
-            getMessage('CantCreateEngineWithUnknownEngineName' ,'oops'));
-    });
-});
-
 describe('Tests for the RetireJsEngine', () => {
     let engine: Engine;
     let allRuleNames: string[];

--- a/packages/code-analyzer-retirejs-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-retirejs-engine/test/plugin.test.ts
@@ -1,0 +1,51 @@
+import {
+    ConfigObject,
+    ConfigValueExtractor,
+    EnginePluginV1,
+    getMessageFromCatalog,
+    SHARED_MESSAGE_CATALOG
+} from "@salesforce/code-analyzer-engine-api";
+import {RetireJsEnginePlugin} from "../src";
+import {RetireJsEngine} from "../src/engine";
+import {getMessage} from "../src/messages";
+
+describe('Tests for the RetireJsEnginePlugin', () => {
+    let plugin: EnginePluginV1;
+    beforeAll(() => {
+        plugin = new RetireJsEnginePlugin();
+    });
+
+    it('When the getAvailableEngineNames method is called then only retire-js is returned', () => {
+        expect(plugin.getAvailableEngineNames()).toEqual(['retire-js']);
+    });
+
+    it('When createEngine is passed retire-js then an RetireJsEngine instance is returned', async () => {
+        expect(await plugin.createEngine('retire-js', {})).toBeInstanceOf(RetireJsEngine);
+    });
+
+    it('When createEngine is passed anything else then an error is thrown', async () => {
+        await expect(plugin.createEngine('oops', {})).rejects.toThrow(
+            getMessage('UnsupportedEngineName' ,'oops'));
+    });
+
+    it('When createEngineConfig is an invalid engine name, then error', async () => {
+        const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor({},'engines.retire-js');
+
+        await expect(plugin.createEngineConfig('oops', configValueExtractor)).rejects.toThrow(
+            getMessage('UnsupportedEngineName' ,'oops'));
+    });
+
+    it('When createEngineConfig is passed an object with an unknown field, then error', async () => {
+        const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor({unknownField: 3},'engines.retire-js');
+
+        await expect(plugin.createEngineConfig('retire-js', configValueExtractor)).rejects.toThrow(
+            getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.retire-js',
+                'unknownField', '[]'));
+    });
+
+    it('When createEngineConfig is passed an an empty object, then the normalized config is returned', async () => {
+        const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor({},'engines.retire-js');
+        const resolvedConfig: ConfigObject = await plugin.createEngineConfig('retire-js', configValueExtractor);
+        expect(resolvedConfig).toEqual({});
+    });
+});

--- a/packages/code-analyzer-retirejs-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-retirejs-engine/test/plugin.test.ts
@@ -28,7 +28,7 @@ describe('Tests for the RetireJsEnginePlugin', () => {
             getMessage('UnsupportedEngineName' ,'oops'));
     });
 
-    it('When createEngineConfig is an invalid engine name, then error', async () => {
+    it('When createEngineConfig is passed an invalid engine name, then error', async () => {
         const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor({},'engines.retire-js');
 
         await expect(plugin.createEngineConfig('oops', configValueExtractor)).rejects.toThrow(


### PR DESCRIPTION
In addition to making everything case insensitive, I also made all unknown config values that a user puts in their config file produce an error. So now no more cases where issues accidentally have a typo in their config file and it gets ignored.