### PR TITLE
CHANGE: @W-17530186@: Update dependencies to latest where possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
-      "integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
+      "integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
       "license": "MIT",
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -118,13 +118,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -134,12 +134,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -239,12 +239,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -507,16 +507,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/types": "^7.26.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.8.2.tgz",
-      "integrity": "sha512-kPlOq6G2BPo3x56qkGOgwas1SJWZYeQR6uXLMFzFrjb/Lisb24VeABNQd1i7JgoQXQzad0F12pfU0BLgIhhR7g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.9.0.tgz",
+      "integrity": "sha512-z2wEUvLanstSl9o7VT/HAI7uFWHkTApz8N1ZpRQtyh8Hg6UbBZKLrg+vMxDED1vZVLu256i2KgYUWysVQyO4tg==",
       "license": "MIT",
       "dependencies": {
         "globals": "^13.24.0",
@@ -1634,9 +1634,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1652,7 +1652,8 @@
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -1695,20 +1696,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.17.0.tgz",
-      "integrity": "sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.20.0.tgz",
+      "integrity": "sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.17.0",
-        "@typescript-eslint/type-utils": "8.17.0",
-        "@typescript-eslint/utils": "8.17.0",
-        "@typescript-eslint/visitor-keys": "8.17.0",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/type-utils": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1719,24 +1720,20 @@
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.17.0.tgz",
-      "integrity": "sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==",
-      "license": "BSD-2-Clause",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
+      "integrity": "sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.17.0",
-        "@typescript-eslint/types": "8.17.0",
-        "@typescript-eslint/typescript-estree": "8.17.0",
-        "@typescript-eslint/visitor-keys": "8.17.0",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1747,22 +1744,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz",
-      "integrity": "sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.20.0.tgz",
+      "integrity": "sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.17.0",
-        "@typescript-eslint/visitor-keys": "8.17.0"
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1773,15 +1766,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.17.0.tgz",
-      "integrity": "sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.20.0.tgz",
+      "integrity": "sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.17.0",
-        "@typescript-eslint/utils": "8.17.0",
+        "@typescript-eslint/typescript-estree": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1791,18 +1784,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.17.0.tgz",
-      "integrity": "sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1813,43 +1802,19 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz",
-      "integrity": "sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==",
-      "license": "BSD-2-Clause",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
+      "integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.17.0",
-        "@typescript-eslint/visitor-keys": "8.17.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.17.0.tgz",
-      "integrity": "sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.17.0",
-        "@typescript-eslint/types": "8.17.0",
-        "@typescript-eslint/typescript-estree": "8.17.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1859,21 +1824,39 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.20.0.tgz",
+      "integrity": "sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.20.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz",
-      "integrity": "sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
+      "integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/types": "8.20.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1897,9 +1880,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
       "license": "ISC"
     },
     "node_modules/acorn": {
@@ -1924,13 +1907,10 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -2021,13 +2001,13 @@
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2056,16 +2036,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
@@ -2087,15 +2057,15 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2105,15 +2075,15 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2123,19 +2093,18 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2157,12 +2126,12 @@
       }
     },
     "node_modules/astronomical": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astronomical/-/astronomical-1.0.0.tgz",
-      "integrity": "sha512-KiCm7qZ6CJqydAXiz6tZ/SiiVYzwt+AMtAcezraHzLXLrK8tK6rBKbg5yn7g8EDqXokxwpUd5vNHeFikYQ3NNw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/astronomical/-/astronomical-1.0.1.tgz",
+      "integrity": "sha512-EAvy2W6Rvoevq8S0LSBMUZVegVjMi7yU1PLX/j5CZwre087cgsLgkFfWdWftuv82KEFIAghnJ+fQkAHtcYilRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "meriyah": "^4.3.9"
+        "meriyah": "^6.0.3"
       }
     },
     "node_modules/async": {
@@ -2328,34 +2297,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true,
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2381,9 +2326,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2400,9 +2345,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.1"
       },
       "bin": {
@@ -2442,36 +2387,45 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2500,9 +2454,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001686",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001686.tgz",
-      "integrity": "sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==",
+      "version": "1.0.30001692",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2518,19 +2472,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dev": true,
-      "license": "MIT/X11",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2731,14 +2672,14 @@
       }
     },
     "node_modules/data-view-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2748,29 +2689,29 @@
       }
     },
     "node_modules/data-view-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "node_modules/data-view-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       },
@@ -2782,9 +2723,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2897,19 +2838,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2920,6 +2848,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -2956,9 +2898,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.68.tgz",
-      "integrity": "sha512-FgMdJlma0OzUYlbrtZ4AeXjKxKPk6KT8WOP8BjcqxWtlg8qyJQjRzPJzUtUn5GBg1oQ26hFs7HOOHJMYiJRnvQ==",
+      "version": "1.5.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+      "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -2992,57 +2934,62 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
-      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
-        "es-define-property": "^1.0.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
-        "get-symbol-description": "^1.0.2",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "internal-slot": "^1.0.7",
-        "is-array-buffer": "^3.0.4",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.1",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
         "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
         "regexp.prototype.flags": "^1.5.3",
-        "safe-array-concat": "^1.1.2",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.9",
-        "string.prototype.trimend": "^1.0.8",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.6",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3052,13 +2999,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -3073,9 +3017,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3085,14 +3029,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3363,9 +3308,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.9.0.tgz",
-      "integrity": "sha512-rLu1s1Wf96TgUUxSw6loVIkNtUjq1Re7A9QdCCHSohnvXEBAjuL420h0T/fMmkQlNsQP2GhQzEUpYHPfxBkvYQ==",
+      "version": "28.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3706,16 +3651,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3746,9 +3691,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3901,9 +3846,10 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -3935,37 +3881,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3976,15 +3891,17 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4022,16 +3939,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4050,6 +3972,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4064,14 +3999,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4081,15 +4016,14 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.2.0"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">= 14"
@@ -4175,35 +4109,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gopd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.1.0.tgz",
-      "integrity": "sha512-FQoVQnqcdk4hVM4JN1eromaun4iuS34oStkdlLENLdpULsuQcTyXj8w7ayhuUfPwEYZ1ZOooOTT6fdA9Vmx/RA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4215,6 +4125,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -4224,10 +4135,13 @@
       "license": "MIT"
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4254,12 +4168,12 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.1.0.tgz",
-      "integrity": "sha512-QLdzI9IIO1Jg7f9GT1gXpPpXArAn6cS31R1eEZqz08Gc+uQ8/XiqHWt17Fiw+2p6oTTIq5GXEpQkAlA88YRl/Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "dunder-proto": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4328,12 +4242,12 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -4431,14 +4345,14 @@
       "license": "ISC"
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4458,13 +4372,14 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4481,12 +4396,15 @@
       "license": "MIT"
     },
     "node_modules/is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4511,12 +4429,12 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
-      "integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -4539,9 +4457,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4554,11 +4472,13 @@
       }
     },
     "node_modules/is-data-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "license": "MIT",
       "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -4569,12 +4489,13 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4593,12 +4514,12 @@
       }
     },
     "node_modules/is-finalizationregistry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
-      "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4628,12 +4549,15 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4666,18 +4590,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4688,12 +4600,12 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
-      "integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -4713,13 +4625,13 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
-      "integrity": "sha512-B6ohK4ZmoftlUe+uvenXSbPJFo6U37BH7oO1B3nQH8f/7h27N56s85MhUtbFJAziz5dcmuR3i8ovUl35zp8pFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "gopd": "^1.1.0",
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
       },
@@ -4743,12 +4655,12 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4771,12 +4683,12 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
-      "integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -4787,14 +4699,14 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
-      "integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "has-symbols": "^1.0.3",
-        "safe-regex-test": "^1.0.3"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4804,12 +4716,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4831,25 +4743,28 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5620,9 +5535,9 @@
       "license": "MIT"
     },
     "node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5672,6 +5587,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5728,13 +5644,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5804,6 +5713,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5821,12 +5739,12 @@
       }
     },
     "node_modules/meriyah": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-4.5.0.tgz",
-      "integrity": "sha512-Rbiu0QPIxTXgOXwiIpRVJfZRQ2FWyfzYrOGBs9SN5RbaXg1CN5ELn/plodwWwluX93yzc4qO/bNIen1ThGFCxw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.0.5.tgz",
+      "integrity": "sha512-SrMqQCox7TTwtftWKHy/ZaVe+ZRpRl20pAgDo+PS9hzcAJrMjYsBJQPPiLXTnjztrqdfGS+Zz99r6Bwvydta1w==",
       "license": "ISC",
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/micromatch": {
@@ -5886,19 +5804,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5928,9 +5833,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
     "node_modules/node-stream-zip": {
@@ -5991,14 +5896,16 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -6041,12 +5948,13 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
-      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
       },
@@ -6097,6 +6005,23 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -6154,19 +6079,19 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
+      "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
       "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.4"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -6283,16 +6208,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6402,19 +6317,19 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
+        "pac-proxy-agent": "^7.1.0",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -6512,18 +6427,19 @@
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.7.tgz",
-      "integrity": "sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "which-builtin-type": "^1.1.4"
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6533,14 +6449,16 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       },
       "engines": {
@@ -6561,17 +6479,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6662,9 +6583,9 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6725,14 +6646,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -6749,15 +6671,31 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6770,6 +6708,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6809,12 +6748,19 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6838,15 +6784,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6904,12 +6904,12 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -7023,15 +7023,18 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
-        "es-object-atoms": "^1.0.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7041,14 +7044,18 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7226,26 +7233,16 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "dev": true,
-      "license": "MIT/X11",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
+      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -7372,30 +7369,30 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7405,18 +7402,18 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
-      "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13",
-        "reflect.getprototypeof": "^1.0.6"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7446,9 +7443,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7459,248 +7456,41 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.18.0.tgz",
-      "integrity": "sha512-PonBkP603E3tt05lDkbOMyaxJjvKqQrXsnow72sVeOFINDE/qNmnnd+f9b4N+U7W6MXnnYyrhtmF2t08QWwUbA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.20.0.tgz",
+      "integrity": "sha512-Kxz2QRFsgbWj6Xcftlw3Dd154b3cEPFqQC+qMZrMypSijPd4UanKKvoKDrJ4o8AIfZFKAF+7sMaEIR8mTElozA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.18.0",
-        "@typescript-eslint/parser": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0"
+        "@typescript-eslint/eslint-plugin": "8.20.0",
+        "@typescript-eslint/parser": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
-      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/type-utils": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
-      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7717,34 +7507,30 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
+        "bluebird": "~3.7.2",
         "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
+        "fs-extra": "^11.2.0",
         "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7762,7 +7548,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -7850,16 +7636,16 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
-      "integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.0",
-        "is-number-object": "^1.1.0",
-        "is-string": "^1.1.0",
-        "is-symbol": "^1.1.0"
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7869,24 +7655,24 @@
       }
     },
     "node_modules/which-builtin-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
         "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
+        "is-date-object": "^1.1.0",
         "is-finalizationregistry": "^1.1.0",
         "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
+        "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7914,15 +7700,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
-      "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -8065,9 +7852,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -8075,10 +7862,10 @@
     },
     "packages/code-analyzer-core": {
       "name": "@salesforce/code-analyzer-core",
-      "version": "0.21.0",
+      "version": "0.22.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@types/sarif": "^2.1.7",
@@ -8096,17 +7883,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-core/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8120,7 +7907,7 @@
     },
     "packages/code-analyzer-engine-api": {
       "name": "@salesforce/code-analyzer-engine-api",
-      "version": "0.16.1",
+      "version": "0.17.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^20.0.0"
@@ -8132,17 +7919,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-engine-api/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8156,44 +7943,44 @@
     },
     "packages/code-analyzer-eslint-engine": {
       "name": "@salesforce/code-analyzer-eslint-engine",
-      "version": "0.18.0",
+      "version": "0.19.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.26.0",
-        "@babel/eslint-parser": "^7.25.9",
+        "@babel/eslint-parser": "^7.26.5",
         "@eslint/js": "^8.57.1",
-        "@lwc/eslint-plugin-lwc": "^1.8.2",
+        "@lwc/eslint-plugin-lwc": "^1.9.0",
         "@lwc/eslint-plugin-lwc-platform": "^5.1.0",
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@salesforce/eslint-config-lwc": "^3.6.0",
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
         "@types/eslint": "^8.56.10",
         "@types/node": "^20.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.17.0",
-        "@typescript-eslint/parser": "^8.17.0",
+        "@typescript-eslint/eslint-plugin": "^8.20.0",
+        "@typescript-eslint/parser": "^8.20.0",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jest": "^28.9.0"
+        "eslint-plugin-jest": "^28.11.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/unzipper": "^0.10.9",
+        "@types/unzipper": "^0.10.10",
         "cross-env": "^7.0.3",
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0",
-        "unzipper": "^0.10.9"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0",
+        "unzipper": "^0.12.3"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-eslint-engine/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8207,10 +7994,10 @@
     },
     "packages/code-analyzer-flowtest-engine": {
       "name": "@salesforce/code-analyzer-flowtest-engine",
-      "version": "0.16.3",
+      "version": "0.17.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "@types/semver": "^7.5.8",
         "@types/tmp": "^0.2.6",
@@ -8224,17 +8011,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-flowtest-engine/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8248,10 +8035,10 @@
     },
     "packages/code-analyzer-pmd-engine": {
       "name": "@salesforce/code-analyzer-pmd-engine",
-      "version": "0.18.0",
+      "version": "0.19.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "@types/semver": "^7.5.8",
         "@types/tmp": "^0.2.6",
@@ -8265,17 +8052,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-pmd-engine/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8289,10 +8076,10 @@
     },
     "packages/code-analyzer-regex-engine": {
       "name": "@salesforce/code-analyzer-regex-engine",
-      "version": "0.16.2",
+      "version": "0.17.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "isbinaryfile": "^5.0.4"
       },
@@ -8303,17 +8090,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-regex-engine/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8327,10 +8114,10 @@
     },
     "packages/code-analyzer-retirejs-engine": {
       "name": "@salesforce/code-analyzer-retirejs-engine",
-      "version": "0.16.2",
+      "version": "0.17.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "@types/tmp": "^0.2.6",
         "isbinaryfile": "^5.0.4",
@@ -8345,17 +8132,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/code-analyzer-retirejs-engine/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8369,10 +8156,10 @@
     },
     "packages/T-E-M-P-L-A-T-E": {
       "name": "@salesforce/t-e-m-p-l-a-t-e",
-      "version": "0.16.1-SNAPSHOT",
+      "version": "0.17.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.16.1",
+        "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
         "@types/node": "^20.0.0"
       },
       "devDependencies": {
@@ -8382,17 +8169,17 @@
         "jest": "^29.7.0",
         "rimraf": "*",
         "ts-jest": "29.2.3",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^7.8.0"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "packages/T-E-M-P-L-A-T-E/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "jest": "^29.7.0",
-    "ts-jest": "29.2.3",
-    "rimraf": "*"
+    "rimraf": "*",
+    "ts-jest": "29.2.3"
   },
   "jest": {
     "testTimeout": 60000,
-    "coverageThreshold":  {
+    "coverageThreshold": {
       "global": {
         "branches": 80,
         "functions": 80,

--- a/packages/T-E-M-P-L-A-T-E/eslint.config.mjs
+++ b/packages/T-E-M-P-L-A-T-E/eslint.config.mjs
@@ -6,7 +6,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/T-E-M-P-L-A-T-E/package.json
+++ b/packages/T-E-M-P-L-A-T-E/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/t-e-m-p-l-a-t-e",
   "description": "T-E-M-P-L-A-T-E",
-  "version": "0.16.1-SNAPSHOT",
+  "version": "0.17.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -14,7 +14,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@types/node": "^20.0.0",
-    "@salesforce/code-analyzer-engine-api": "0.16.1"
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT"
   },
   "devDependencies": {
     "@eslint/js": "^8.57.1",
@@ -23,8 +23,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-core/eslint.config.mjs
+++ b/packages/code-analyzer-core/eslint.config.mjs
@@ -8,7 +8,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-core/package.json
+++ b/packages/code-analyzer-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-core",
   "description": "Core Package for the Salesforce Code Analyzer",
-  "version": "0.21.0",
+  "version": "0.22.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.16.1",
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@types/sarif": "^2.1.7",
@@ -31,8 +31,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -103,7 +103,7 @@ export class CodeAnalyzer {
         try {
             try {
                 resolvedModulePath = require.resolve(enginePluginModulePath, {paths: [this.config.getConfigRoot()]});
-            } catch (err) {
+            } catch (err) /* istanbul ignore next */ {
                 // On windows, there is an edge case where a standalone file in the same directory as the user's config
                 // file may not be resolved by require.resolve if given as just the file name. So we attempt to resolve
                 // this using path.resolve for this edge case.

--- a/packages/code-analyzer-core/src/results.ts
+++ b/packages/code-analyzer-core/src/results.ts
@@ -160,7 +160,8 @@ export class UnexpectedEngineErrorViolation implements Violation {
 
     getMessage(): string {
         return getMessage('UnexpectedEngineErrorViolationMessage', this.engineName,
-            this.error.stack ? this.error.stack : this.error.message); // Prefer to get the whole stack when possible
+            this.error.stack ? this.error.stack :  // Prefer to get the whole stack when possible
+                /* istanbul ignore next */ this.error.message);
     }
 
     getCodeLocations(): CodeLocation[] {

--- a/packages/code-analyzer-engine-api/eslint.config.mjs
+++ b/packages/code-analyzer-engine-api/eslint.config.mjs
@@ -8,7 +8,11 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-engine-api/package.json
+++ b/packages/code-analyzer-engine-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-engine-api",
   "description": "Engine API Package for the Salesforce Code Analyzer",
-  "version": "0.16.1",
+  "version": "0.17.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -24,8 +24,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-eslint-engine/eslint.config.mjs
+++ b/packages/code-analyzer-eslint-engine/eslint.config.mjs
@@ -6,7 +6,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-eslint-engine/package.json
+++ b/packages/code-analyzer-eslint-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-eslint-engine",
   "description": "Plugin package that adds 'eslint' as an engine into Salesforce Code Analyzer",
-  "version": "0.18.0",
+  "version": "0.19.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -14,31 +14,31 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@babel/core": "^7.26.0",
-    "@babel/eslint-parser": "^7.25.9",
+    "@babel/eslint-parser": "^7.26.5",
     "@eslint/js": "^8.57.1",
-    "@lwc/eslint-plugin-lwc": "^1.8.2",
+    "@lwc/eslint-plugin-lwc": "^1.9.0",
     "@lwc/eslint-plugin-lwc-platform": "^5.1.0",
-    "@salesforce/code-analyzer-engine-api": "0.16.1",
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
     "@salesforce/eslint-config-lwc": "^3.6.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
     "@types/eslint": "^8.56.10",
     "@types/node": "^20.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.17.0",
-    "@typescript-eslint/parser": "^8.17.0",
+    "@typescript-eslint/eslint-plugin": "^8.20.0",
+    "@typescript-eslint/parser": "^8.20.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-jest": "^28.9.0"
+    "eslint-plugin-jest": "^28.11.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/unzipper": "^0.10.9",
+    "@types/unzipper": "^0.10.10",
     "cross-env": "^7.0.3",
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0",
-    "unzipper": "^0.10.9"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0",
+    "unzipper": "^0.12.3"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-eslint-engine/src/rule-mappings.ts
+++ b/packages/code-analyzer-eslint-engine/src/rule-mappings.ts
@@ -1101,6 +1101,10 @@ export const RULE_MAPPINGS: Record<string, {severity: SeverityLevel, tags: strin
         severity: SeverityLevel.Moderate,
         tags: [/* NOT RECOMMENDED */    COMMON_TAGS.CATEGORIES.BEST_PRACTICES, COMMON_TAGS.LANGUAGES.TYPESCRIPT]
     },
+    "@typescript-eslint/no-misused-spread": {
+        severity: SeverityLevel.High,
+        tags: [/* NOT RECOMMENDED */    COMMON_TAGS.CATEGORIES.ERROR_PRONE,    COMMON_TAGS.LANGUAGES.TYPESCRIPT]
+    },
     "@typescript-eslint/naming-convention": {
         severity: SeverityLevel.Moderate,
         tags: [/* NOT RECOMMENDED */    COMMON_TAGS.CATEGORIES.BEST_PRACTICES, COMMON_TAGS.LANGUAGES.TYPESCRIPT]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfig.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfig.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {
@@ -1181,6 +1181,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1641,7 +1653,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1847,7 +1859,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfigAndCustomConfigModifyingExistingRules.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfigAndCustomConfigModifyingExistingRules.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {
@@ -1181,6 +1181,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1641,7 +1653,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1847,7 +1859,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfigAndCustomConfigWithNewRules.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfigAndCustomConfigWithNewRules.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {
@@ -1181,6 +1181,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1641,7 +1653,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1847,7 +1859,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfig_NoJavascriptFilesInWorkspace.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfig_NoJavascriptFilesInWorkspace.goldfile.json
@@ -619,6 +619,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1079,7 +1091,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1285,7 +1297,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfig_NoTypescriptFilesInWorkspace.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DefaultConfig_NoTypescriptFilesInWorkspace.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DisabledJavascriptBaseConfig.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DisabledJavascriptBaseConfig.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {
@@ -1181,6 +1181,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1641,7 +1653,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1847,7 +1859,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DisabledLwcBaseConfig.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DisabledLwcBaseConfig.goldfile.json
@@ -619,6 +619,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1079,7 +1091,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1285,7 +1297,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DisabledTypescriptBaseConfig.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_DisabledTypescriptBaseConfig.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_OnlyLwcBaseConfig.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_OnlyLwcBaseConfig.goldfile.json
@@ -334,7 +334,7 @@
     ],
     "description": "prevent public property reassignments",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-api-reassignments.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-api-reassignments.md"
     ]
   },
   {
@@ -348,7 +348,7 @@
     ],
     "description": "restrict usage of async operations",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-async-operation.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-async-operation.md"
     ]
   },
   {
@@ -362,7 +362,7 @@
     ],
     "description": "no attributes during construction",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-attributes-during-construction.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-attributes-during-construction.md"
     ]
   },
   {
@@ -376,7 +376,7 @@
     ],
     "description": "disallow usage of deprecated LWC APIs",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-deprecated.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-deprecated.md"
     ]
   },
   {
@@ -390,7 +390,7 @@
     ],
     "description": "restrict unexpected imports from the lwc package",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-disallowed-lwc-imports.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-disallowed-lwc-imports.md"
     ]
   },
   {
@@ -404,7 +404,7 @@
     ],
     "description": "disallow DOM query at the document level.",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-document-query.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-document-query.md"
     ]
   },
   {
@@ -418,7 +418,7 @@
     ],
     "description": "disallow usage of \"innerHtml\"",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-inner-htm.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-inner-htm.md"
     ]
   },
   {
@@ -432,7 +432,7 @@
     ],
     "description": "disallow public property to start with an upper case character",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-leading-uppercase-api-name.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-leading-uppercase-api-name.md"
     ]
   },
   {
@@ -446,7 +446,7 @@
     ],
     "description": "prevent accessing the immediate children of this.template",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-template-children.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-template-children.md"
     ]
   },
   {
@@ -460,7 +460,7 @@
     ],
     "description": "restrict unexpected wire adapter usages",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unexpected-wire-adapter-usages.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unexpected-wire-adapter-usages.md"
     ]
   },
   {
@@ -474,7 +474,7 @@
     ],
     "description": "restrict usage of unknown wire adapters",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/no-unknown-wire-adapters.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/no-unknown-wire-adapters.md"
     ]
   },
   {
@@ -488,7 +488,7 @@
     ],
     "description": "suggest usage of \"CustomEvent\" over \"Event\" constructor",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/prefer-custom-event.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/prefer-custom-event.md"
     ]
   },
   {
@@ -502,7 +502,7 @@
     ],
     "description": "validate api decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-api.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-api.md"
     ]
   },
   {
@@ -516,7 +516,7 @@
     ],
     "description": "validate graphql error callback parameter",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-graphql-error-callback-parameter.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-graphql-error-callback-parameter.md"
     ]
   },
   {
@@ -530,7 +530,7 @@
     ],
     "description": "validate track decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-track.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-track.md"
     ]
   },
   {
@@ -544,7 +544,7 @@
     ],
     "description": "validate wire decorator usage",
     "resourceUrls": [
-      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.8.2/docs/rules/valid-wire.md"
+      "https://github.com/salesforce/eslint-plugin-lwc/blob/v1.9.0/docs/rules/valid-wire.md"
     ]
   },
   {

--- a/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_OnlyTypescriptBaseConfig.goldfile.json
+++ b/packages/code-analyzer-eslint-engine/test/test-data/legacyConfigCases/rules_OnlyTypescriptBaseConfig.goldfile.json
@@ -619,6 +619,18 @@
     ]
   },
   {
+    "name": "@typescript-eslint/no-misused-spread",
+    "severityLevel": 2,
+    "tags": [
+      "ErrorProne",
+      "Typescript"
+    ],
+    "description": "Disallow using the spread operator when it might cause unexpected behavior",
+    "resourceUrls": [
+      "https://typescript-eslint.io/rules/no-misused-spread"
+    ]
+  },
+  {
     "name": "@typescript-eslint/no-mixed-enums",
     "severityLevel": 2,
     "tags": [
@@ -1079,7 +1091,7 @@
       "BestPractices",
       "Typescript"
     ],
-    "description": "Enforce non-null assertions over explicit type casts",
+    "description": "Enforce non-null assertions over explicit type assertions",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     ]
@@ -1285,7 +1297,7 @@
       "ErrorProne",
       "Typescript"
     ],
-    "description": "Enforce using type parameter when calling `Array#reduce` instead of casting",
+    "description": "Enforce using type parameter when calling `Array#reduce` instead of using a type assertion",
     "resourceUrls": [
       "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     ]

--- a/packages/code-analyzer-flowtest-engine/eslint.config.mjs
+++ b/packages/code-analyzer-flowtest-engine/eslint.config.mjs
@@ -6,7 +6,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-flowtest-engine/package.json
+++ b/packages/code-analyzer-flowtest-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-flowtest-engine",
   "description": "Plugin package that adds 'flowtest' as an engine into Salesforce Code Analyzer",
-  "version": "0.16.3",
+  "version": "0.17.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.16.1",
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.5.8",
     "@types/tmp": "^0.2.6",
@@ -27,8 +27,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-flowtest-engine/src/config.ts
+++ b/packages/code-analyzer-flowtest-engine/src/config.ts
@@ -79,7 +79,7 @@ class FlowTestEngineConfigValueExtractor {
                 if (version !== null && version.compare(MINIMUM_PYTHON_VERSION) >= 0) {
                     return pythonCommand;
                 }
-            } catch (err) {
+            } catch (_err) {
                 // continue
             }
         }

--- a/packages/code-analyzer-flowtest-engine/src/python/FlowTestCommandWrapper.ts
+++ b/packages/code-analyzer-flowtest-engine/src/python/FlowTestCommandWrapper.ts
@@ -74,7 +74,7 @@ export class RunTimeFlowTestCommandWrapper implements FlowTestCommandWrapper {
         let parsedResults: object;
         try {
             parsedResults = JSON.parse(outputFileContents);
-        } catch (e) {
+        } catch (_err) {
             throw new Error(getMessage('ResultsFileNotValidJson', outputFileContents));
         }
 

--- a/packages/code-analyzer-pmd-engine/eslint.config.mjs
+++ b/packages/code-analyzer-pmd-engine/eslint.config.mjs
@@ -6,7 +6,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-pmd-engine",
   "description": "Plugin package that adds 'pmd' and 'cpd' as engines into Salesforce Code Analyzer",
-  "version": "0.18.0",
+  "version": "0.19.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -14,7 +14,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@types/node": "^20.0.0",
-    "@salesforce/code-analyzer-engine-api": "0.16.1",
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
     "@types/tmp": "^0.2.6",
     "tmp": "^0.2.3",
     "@types/semver": "^7.5.8",
@@ -27,8 +27,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-regex-engine/eslint.config.mjs
+++ b/packages/code-analyzer-regex-engine/eslint.config.mjs
@@ -6,7 +6,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-regex-engine",
   "description": "Plugin package that adds 'regex' as an engine into Salesforce Code Analyzer",
-  "version": "0.16.2",
+  "version": "0.17.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.16.1",
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
     "@types/node": "^20.0.0",
     "isbinaryfile": "^5.0.4"
   },
@@ -24,8 +24,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-regex-engine/src/engine.ts
+++ b/packages/code-analyzer-regex-engine/src/engine.ts
@@ -119,7 +119,7 @@ export class RegexEngine extends Engine {
             try {
                 await fs.promises.access(medataFileName, fs.constants.F_OK);
                 fileContents = fileContents + await fs.promises.readFile(medataFileName, {encoding: 'utf8'}) ;
-            } catch (err) {
+            } catch (_err) {
                 // Silently proceed if -meta.xml file doesn't exist or there was a problem reading it.
             }
         }

--- a/packages/code-analyzer-retirejs-engine/eslint.config.mjs
+++ b/packages/code-analyzer-retirejs-engine/eslint.config.mjs
@@ -8,7 +8,11 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     {
         rules: {
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            "@typescript-eslint/no-unused-vars": ["error", {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }]
         }
     }
 );

--- a/packages/code-analyzer-retirejs-engine/package.json
+++ b/packages/code-analyzer-retirejs-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-retirejs-engine",
   "description": "Plugin package that adds 'retire-js' as an engine into Salesforce Code Analyzer",
-  "version": "0.16.2",
+  "version": "0.17.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@salesforce/code-analyzer-engine-api": "0.16.1",
+    "@salesforce/code-analyzer-engine-api": "0.17.0-SNAPSHOT",
     "@types/node": "^20.0.0",
     "@types/tmp": "^0.2.6",
     "isbinaryfile": "^5.0.4",
@@ -28,8 +28,8 @@
     "jest": "^29.7.0",
     "rimraf": "*",
     "ts-jest": "29.2.3",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^7.8.0"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Notes:
* Can't upgrade ts-jest past 29.2.3 due to:
https://github.com/kulshekhar/ts-jest/issues/4641
* Can't upgrade @lwc/eslint-plugin-lwc past 1.9.0 due to:
https://github.com/salesforce/eslint-config-lwc/issues/143
* And obviously we must stick with node v20 and eslint v8 to keep our minimum dependencies here for our customers.