### PR TITLE
FIX(retire-js): @W-17711048@: Use spawn instead of exec to fix issue with spaces in command path

### DIFF
--- a/packages/code-analyzer-retirejs-engine/src/executor.ts
+++ b/packages/code-analyzer-retirejs-engine/src/executor.ts
@@ -1,14 +1,11 @@
 import {Finding} from "retire/lib/types";
-import {exec, ExecException} from "node:child_process";
-import {promisify} from "node:util";
+import {ChildProcessWithoutNullStreams, spawn} from "node:child_process";
 import fs from "node:fs";
 import * as utils from "./utils";
 import path from "node:path";
 import {DecoratedStreamZip} from './zip-decorator';
 import {getMessage} from "./messages";
 import {LogLevel} from "@salesforce/code-analyzer-engine-api";
-
-const execAsync = promisify(exec);
 
 // To handle the special case where a vulnerable library is found within a zip archive, a RetireJsExecutor can use this
 // marker to update the file field to look like <zip_file>::[ZIPPED_FILE]::<embedded_file> which the engine handles.
@@ -64,25 +61,22 @@ export class SimpleRetireJsExecutor implements RetireJsExecutor {
 
     private async scanFolder(folder: string): Promise<Finding[]> {
         const tempOutputFile: string = (await utils.createTempDir()) + path.sep + 'output.json';
-        const command: string = RETIRE_COMMAND +
-            ` --path "${folder}"` +
-            ` --exitwith 13` +
-            ` --outputformat jsonsimple` +
-            ` --outputpath "${tempOutputFile}"` +
-            ` --jsrepo "${RETIRE_JS_VULN_REPO_FILE}"` +
-            ` --ext "${JS_EXTENSIONS.map(ext => ext.replace('.','')).join(',')}"`;
+        const commandArgs: string[] = [
+            '--path', folder,
+            '--exitwith', '13',
+            '--outputformat', 'jsonsimple',
+            '--outputpath', tempOutputFile,
+            '--jsrepo', RETIRE_JS_VULN_REPO_FILE,
+            '--ext', JS_EXTENSIONS.map(ext => ext.replace('.','')).join(',')
+        ]
 
-        this.emitLogEvent(LogLevel.Fine, `Executing command: ${command}`);
+        const cmdStr: string = `${RETIRE_COMMAND} ${commandArgs.map(a => a.includes(' ') ? `"${a}"` : a).join(',')}`;
+        this.emitLogEvent(LogLevel.Fine, `Executing command: ${cmdStr}`);
         try {
-            await execAsync(command, {encoding: 'utf-8'});
-        } catch (err) {
-            const execError: ExecException = err as ExecException;
-            /* istanbul ignore next */
-            if (execError.code != 13) {
-                throw new Error(getMessage('UnexpectedErrorWhenExecutingCommand', command, execError.message) +
-                    `\n\n[stdout]:\n${execError.stdout}\n[stderror]:\n${execError.stderr}`,
-                    {cause: err});
-            }
+            await this.runCmdWithArgs(RETIRE_COMMAND, commandArgs);
+        } catch (err) /* istanbul ignore next */ {
+            const errMsg: string = err instanceof Error ? (err as Error).message : `${err}`;
+            throw new Error(getMessage('UnexpectedErrorWhenExecutingCommand', cmdStr, errMsg));
         }
 
         this.emitLogEvent(LogLevel.Fine, `Parsing output file: ${tempOutputFile}`);
@@ -94,6 +88,27 @@ export class SimpleRetireJsExecutor implements RetireJsExecutor {
             throw new Error(getMessage('UnexpectedErrorWhenProcessingOutputFile', tempOutputFile, (err as Error).message),
                 {cause: err});
         }
+    }
+
+    private async runCmdWithArgs(cmd:string, argArray: string[]): Promise<void> {
+        return new Promise<void>((res, rej) => {
+            const childProcess: ChildProcessWithoutNullStreams = spawn(cmd, argArray);
+            let output: string = '';
+            /* istanbul ignore next */
+            const processOutput = (data: string) => output += data;
+            childProcess.stdout.on('data', processOutput);
+            childProcess.stderr.on('data', processOutput);
+            /* istanbul ignore next */
+            childProcess.on('error', err => rej(err.message));
+            childProcess.on('exit', (code: number) => {
+                /* istanbul ignore else */
+                if (code === 0 || code === 13) { // 0: success with 0 found,  13: success with >0 found
+                    res();
+                } else {
+                    rej(output);
+                }
+            });
+        });
     }
 }
 

--- a/packages/code-analyzer-retirejs-engine/src/executor.ts
+++ b/packages/code-analyzer-retirejs-engine/src/executor.ts
@@ -73,7 +73,7 @@ export class SimpleRetireJsExecutor implements RetireJsExecutor {
         const cmdStr: string = `${RETIRE_COMMAND} ${commandArgs.map(a => a.includes(' ') ? `"${a}"` : a).join(',')}`;
         this.emitLogEvent(LogLevel.Fine, `Executing command: ${cmdStr}`);
         try {
-            await this.runCmdWithArgs(RETIRE_COMMAND, commandArgs);
+            await this.runRetireCmdWithArgs(RETIRE_COMMAND, commandArgs);
         } catch (err) /* istanbul ignore next */ {
             const errMsg: string = err instanceof Error ? (err as Error).message : `${err}`;
             throw new Error(getMessage('UnexpectedErrorWhenExecutingCommand', cmdStr, errMsg));
@@ -90,9 +90,10 @@ export class SimpleRetireJsExecutor implements RetireJsExecutor {
         }
     }
 
-    private async runCmdWithArgs(cmd:string, argArray: string[]): Promise<void> {
+    private async runRetireCmdWithArgs(cmd:string, argArray: string[]): Promise<void> {
         return new Promise<void>((res, rej) => {
-            const childProcess: ChildProcessWithoutNullStreams = spawn(cmd, argArray);
+            const childProcess: ChildProcessWithoutNullStreams = spawn(cmd, argArray,
+                { shell: process.platform.startsWith('win') }); // Use shell on window's machines
             let output: string = '';
             /* istanbul ignore next */
             const processOutput = (data: string) => output += data;

--- a/packages/code-analyzer-retirejs-engine/src/messages.ts
+++ b/packages/code-analyzer-retirejs-engine/src/messages.ts
@@ -25,7 +25,7 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
         `Vulnerability details: %s`,
 
     UnexpectedErrorWhenExecutingCommand:
-        `An unexpected error was thrown when executing the command '%s': %s`,
+        `An unexpected error was thrown when executing the command '%s'.\nOutput from command:\n%s`,
 
     UnexpectedErrorWhenProcessingOutputFile:
         `An unexpected error was thrown when processing the output file '%s': %s`,


### PR DESCRIPTION
This isn't something we can easily unit test because the command is run from the directory in which the code analyzer plugin is installed. So no unit tests were added.
But I was able to reproduce the issue with:
```
git clone git@github.com:forcedotcom/code-analyzer-core.git "folder with spaces"
cd "folder with spaces"
npm install
npm run build
npm run test
```
which made the retire-js tests fail.

With this change, the tests pass again.
