### PR TITLE
FIX (Regex) @W-17809567@ Fixed ENFILE/EMFILE errors for Regex engine

### DIFF
--- a/packages/code-analyzer-regex-engine/src/engine.ts
+++ b/packages/code-analyzer-regex-engine/src/engine.ts
@@ -93,9 +93,20 @@ export class RegexEngine extends Engine {
 
     async runRules(ruleNames: string[], runOptions: RunOptions): Promise<EngineRunResults> {
         const textFiles: string[] = await this.getTextFiles(runOptions.workspace);
-        const ruleRunPromises: Promise<Violation[]>[] = textFiles.map(file => this.runRulesForFile(file, ruleNames));
+        let batchMultiplier = 0;
+        let violations: Violation[] = [];
+        while (batchMultiplier * 1000 < textFiles.length) {
+            // Turns out there's a system-level limit on how many files can be open at once. In order to avoid hitting
+            // this limit while still reaping the benefits of `Promise.all()`, we'll process the files in batches of
+            // 1000.
+            const textFileBatch = textFiles.slice(batchMultiplier * 1000, (batchMultiplier + 1) * 1000);
+            const ruleRunPromises: Promise<Violation[]>[] = textFileBatch.map(file => this.runRulesForFile(file, ruleNames));
+            const newViolations = (await Promise.all(ruleRunPromises)).flat();
+            violations = [...violations, ...newViolations];
+            batchMultiplier++;
+        }
         return {
-            violations: (await Promise.all(ruleRunPromises)).flat()
+            violations
         };
     }
 


### PR DESCRIPTION
This PR resolves https://github.com/forcedotcom/sfdx-scanner/issues/1740.
The root cause is that the `regex` engine was attempting to process every single file in the workspace in parallel via `async/await` and `Promise.all` instead of doing it serially. In a truly massive workspace (like, >20k files), it's possible to hit the system-level limit on how many files are allowed to be open at once.
The fix is that the engine has been modified to process files in batches of 1000, allowing for a more controlled level of parallelism.
I couldn't think of a way to add an automated test for this, short of adding 20,000 new files to repo, so I chose not to.