### PR TITLE
NEW (SFGE) @W-17915919@ (2 of 2) Implemented java_command config for SFGE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1655,9 +1655,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -8173,11 +8173,9 @@
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.21.0-SNAPSHOT",
         "@types/node": "^20.0.0",
-        "@types/tmp": "^0.2.6",
         "isbinaryfile": "^5.0.4",
         "node-stream-zip": "^1.15.0",
-        "retire": "^5.2.5",
-        "tmp": "^0.2.3"
+        "retire": "^5.2.5"
       },
       "devDependencies": {
         "@eslint/js": "^8.57.1",
@@ -8214,7 +8212,9 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.21.0-SNAPSHOT",
-        "@types/node": "^20.0.0"
+        "@types/node": "^20.0.0",
+        "@types/semver": "^7.7.0",
+        "semver": "^7.7.1"
       },
       "devDependencies": {
         "@eslint/js": "^8.57.1",

--- a/packages/code-analyzer-sfge-engine/package.json
+++ b/packages/code-analyzer-sfge-engine/package.json
@@ -13,8 +13,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-      "@salesforce/code-analyzer-engine-api": "0.21.0-SNAPSHOT",
-      "@types/node": "^20.0.0"
+    "@salesforce/code-analyzer-engine-api": "0.21.0-SNAPSHOT",
+    "@types/node": "^20.0.0",
+    "@types/semver": "^7.7.0",
+    "semver": "^7.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^8.57.1",

--- a/packages/code-analyzer-sfge-engine/src/config.ts
+++ b/packages/code-analyzer-sfge-engine/src/config.ts
@@ -2,9 +2,21 @@ import {
     ConfigDescription,
     ConfigValueExtractor,
 } from "@salesforce/code-analyzer-engine-api";
+import {indent} from '@salesforce/code-analyzer-engine-api/utils';
 import {getMessage} from "./messages";
+import {JavaVersionIdentifier} from "./java-version-identifier";
+import path from "node:path";
+import {SemVer} from "semver";
+
+const DEFAULT_JAVA_COMMAND: string = 'java';
+const MINIMUM_JAVA_VERSION: string = '11.0.0';
 
 export type SfgeEngineConfig = {
+    // Indicates the specific "java" command to use for the 'sfge' engine.
+    // May be provided as the name of a command that exists on the path, or an absolute file path location.
+    //   Example: '/path/to/jdk/openjdk_11.0.17.0.1_11.60.54_x64/bin/java'
+    // If not defined, or equal to null, then an attempt will be made to automatically discover a 'java' command from your environment.
+    java_command: string;
     disable_limit_reached_violations: boolean;
     java_max_heap_size?: string;
     java_thread_count: number;
@@ -12,6 +24,7 @@ export type SfgeEngineConfig = {
 }
 
 export const DEFAULT_SFGE_ENGINE_CONFIG: SfgeEngineConfig = {
+    java_command: DEFAULT_JAVA_COMMAND,
     disable_limit_reached_violations: false,
     java_max_heap_size: undefined,
     java_thread_count: 4,
@@ -30,6 +43,11 @@ export const SFGE_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {
             descriptionText: getMessage('ConfigFieldDescription_disable_limit_reached_violations'),
             valueType: "boolean",
             defaultValue: DEFAULT_SFGE_ENGINE_CONFIG.disable_limit_reached_violations
+        },
+        java_command: {
+            descriptionText: getMessage('ConfigFieldDescription_java_command'),
+            valueType: "string",
+            defaultValue: null // Using null for doc and since it indicates that the value is calculated based on the environment
         },
         // Specifies the maximum size (in bytes) of the Java heap. The specified value is appended to the '-Xmx' Java
         // command option. The value must be a multiple of 1024, and greater than 2MB. Append the letter 'k' or 'K' to
@@ -59,10 +77,11 @@ export const SFGE_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {
 
 const JAVA_HEAP_SIZE_REGEX: RegExp = /^\d+[kmg]?$/i;
 
-export async function validateAndNormalizeConfig(cve: ConfigValueExtractor): Promise<SfgeEngineConfig> {
-    cve.validateContainsOnlySpecifiedKeys(['disable_limit_reached_violations', 'java_max_heap_size', 'java_thread_count', 'java_thread_timeout']);
-    const sfgeConfigValueExtractor: SfgeConfigValueExtractor = new SfgeConfigValueExtractor(cve);
+export async function validateAndNormalizeConfig(cve: ConfigValueExtractor, javaVersionIdentifier: JavaVersionIdentifier): Promise<SfgeEngineConfig> {
+    cve.validateContainsOnlySpecifiedKeys(['disable_limit_reached_violations', 'java_command', 'java_max_heap_size', 'java_thread_count', 'java_thread_timeout']);
+    const sfgeConfigValueExtractor: SfgeConfigValueExtractor = new SfgeConfigValueExtractor(cve, javaVersionIdentifier);
     return {
+        java_command: await sfgeConfigValueExtractor.extractJavaCommand(),
         disable_limit_reached_violations: sfgeConfigValueExtractor.extractBooleanValue('disable_limit_reached_violations'),
         java_max_heap_size: sfgeConfigValueExtractor.extractJavaMaxHeapSize(),
         java_thread_count: sfgeConfigValueExtractor.extractNumericValue('java_thread_count'),
@@ -72,9 +91,71 @@ export async function validateAndNormalizeConfig(cve: ConfigValueExtractor): Pro
 
 class SfgeConfigValueExtractor {
     private readonly delegateExtractor: ConfigValueExtractor;
+    private readonly javaVersionIdentifier: JavaVersionIdentifier;
 
-    public constructor(delegateExtractor: ConfigValueExtractor) {
+    public constructor(delegateExtractor: ConfigValueExtractor, javaVersionIdentifier: JavaVersionIdentifier) {
         this.delegateExtractor = delegateExtractor;
+        this.javaVersionIdentifier = javaVersionIdentifier;
+    }
+
+    public async extractJavaCommand(): Promise<string> {
+        const javaCommand: string | undefined = this.delegateExtractor.extractString('java_command');
+        if (!javaCommand) {
+            return await this.attemptToAutoDetectJavaCommand();
+        }
+
+        try {
+            await this.validateJavaCommandContainsValidVersion(javaCommand);
+        } catch (err) {
+            throw new Error(getMessage('InvalidConfigValue',
+                this.delegateExtractor.getFieldPath('java_command'), (err as Error).message));
+        }
+        return javaCommand;
+    }
+
+    private async attemptToAutoDetectJavaCommand(): Promise<string> {
+        const commandsToAttempt: string[] = [
+            // Environment variables specifying JAVA HOME take precedence (if they exist)
+            ...['JAVA_HOME', 'JRE_HOME', 'JDK_HOME'].filter(v => process.env[v]) // only keep vars that have a non-empty defined value
+                .map(/* istanbul ignore next */ v => path.join(process.env[v]!, 'bin', 'java')),
+
+            // Attempt to just use the default java command that might be already on the path as a last attempt
+            DEFAULT_JAVA_COMMAND
+        ];
+
+        const errorMessages: string[] = [];
+        for (const possibleJavaCommand of commandsToAttempt) {
+            try {
+                // Yes we want to have an await statement in a loop in this case since we want to try one at a time
+                await this.validateJavaCommandContainsValidVersion(possibleJavaCommand);
+                return possibleJavaCommand;
+            } catch (err) {
+                errorMessages.push((err as Error).message);
+            }
+        }
+        const consolidatedErrorMessages: string = errorMessages.map((msg: string, idx: number) =>
+            indent(`Attempt ${idx + 1}:\n${indent(msg)}`, '  | ')).join('\n');
+        throw new Error(getMessage('CouldNotLocateJava',
+            MINIMUM_JAVA_VERSION,
+            consolidatedErrorMessages,
+            this.delegateExtractor.getFieldPath('java_command'),
+            this.delegateExtractor.getFieldPath('disable_engine')));
+    }
+
+    private async validateJavaCommandContainsValidVersion(javaCommand: string): Promise<void> {
+        let version: SemVer | null;
+        try {
+            version = await this.javaVersionIdentifier.identifyJavaVersion(javaCommand);
+        } catch (err) {
+            /* istanbul ignore next */
+            const errMsg: string = err instanceof Error ? err.message : String(err);
+            throw new Error(getMessage('JavaVersionCheckProducedError', javaCommand, indent(errMsg, '  | ')));
+        }
+        if (!version) {
+            throw new Error(getMessage('UnrecognizableJavaVersion', javaCommand));
+        } else if (version.compare(MINIMUM_JAVA_VERSION) < 0) {
+            throw new Error(getMessage('JavaBelowMinimumVersion', javaCommand, version.toString(), MINIMUM_JAVA_VERSION));
+        }
     }
 
     public extractJavaMaxHeapSize(): string | undefined {

--- a/packages/code-analyzer-sfge-engine/src/java-version-identifier.ts
+++ b/packages/code-analyzer-sfge-engine/src/java-version-identifier.ts
@@ -1,0 +1,57 @@
+import {coerce, SemVer} from 'semver';
+import cp from 'node:child_process';
+
+export interface JavaVersionIdentifier {
+    identifyJavaVersion(javaCommand: string): Promise<SemVer|null>;
+}
+
+export class RuntimeJavaVersionIdentifier implements JavaVersionIdentifier {
+    private readonly cache: Map<string, SemVer|null> = new Map();
+
+    identifyJavaVersion(javaCommand: string): Promise<SemVer|null> {
+        if (this.cache.has(javaCommand)) {
+            return Promise.resolve(this.cache.get(javaCommand)!);
+        }
+
+        return new Promise<SemVer|null>((resolve, reject) => {
+            // We are using "java -version" which has output that typically looks like:
+            // * (from MacOS): "openjdk version "11.0.6" 2020-01-14 LTS\nOpenJDK Runtime Environment Zulu11.37+17-CA (build 11.0.6+10-LTS)\nOpenJDK 64-Bit Server VM Zulu11.37+17-CA (build 11.0.6+10-LTS, mixed mode)\n"
+            // From much research this output typically has the word "version " and then either a number with or without quotes.
+            // If instead we used java --version then the output would look something like:
+            // * (from Win10): "openjdk 14 2020-03-17\r\nOpenJDK Runtime Environment (build 14+36-1461)\r\nOpenJDK 64-Bit Server VM (build 14+36-1461, mixed mode, sharing)\r\n"
+            // Notice it doesn't have the word "version" which is why we don't call "--version" but instead call "-version".
+            const childProcess: cp.ChildProcessWithoutNullStreams = cp.spawn(javaCommand, ['-version']);
+
+            let stderr: string = '';
+            childProcess.stderr.on('data', (data: Buffer) => {
+                stderr += data.toString();
+            });
+            childProcess.on('exit', (code: number) => {
+                /* istanbul ignore else */
+                if (code === 0) {
+                    // Oddly enough the -version command is documented to go to stderr and not stdout
+                    const version: SemVer|null = _extractJavaVersionFrom(stderr);
+                    this.cache.set(javaCommand, version);
+                    resolve(version);
+                } else {
+                    // A non-0 exit code indicates a failure. So just reject with whatever `stderr` was.
+                    reject(stderr);
+                }
+            });
+            childProcess.on('error', (err: Error) => {
+                reject(err.message);
+            });
+        });
+    }
+}
+
+export function _extractJavaVersionFrom(javaVersionOutput: string): SemVer|null {
+    // First we'll see if the word "version" exists with the version number and use that first.
+    const matchedParts: RegExpMatchArray | null = javaVersionOutput.match(/version\s+"?(\d+(\.\d+)*)"?/i);
+    const versionString: string | undefined = matchedParts?.[1];
+    if (versionString) {
+        return coerce(versionString);
+    }
+    // Otherwise we'll try to get the version number the crude way by just looking for the first number (which is what coerce does)
+    return coerce(javaVersionOutput);
+}

--- a/packages/code-analyzer-sfge-engine/src/messages.ts
+++ b/packages/code-analyzer-sfge-engine/src/messages.ts
@@ -14,6 +14,11 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
         `complexity is dynamically calculated based on the max Java heap size available, but in some cases you may\n` +
         `desire to disable this check in addition to increasing java_max_heap_size.`,
 
+    ConfigFieldDescription_java_command:
+        `Indicates the specific 'java' command associated with the JRE or JDK to use for the 'sfge' engine.\n` +
+        `May be provided as the name of a command that exists on the path, or an absolute file path location.\n` +
+        `If unspecified, or specified as null, then an attempt will be made to automatically discover a 'java' command from your environment.`,
+
     ConfigFieldDescription_java_max_heap_size:
         `Specifies the maximum size (in bytes) of the Java heap. The specified value is appended to the '-Xmx' Java\n` +
         `command option. The value must be a multiple of 1024, and greater than 2MB. Append the letter 'k' or 'K' to\n` +
@@ -42,6 +47,21 @@ const MESSAGE_CATALOG : { [key: string]: string } = {
 
     InvalidMemoryMultiple:
         `The amount of memory specified in bytes must be divisible by 1024`,
+
+    JavaVersionCheckProducedError:
+        `When attempting to find the version of command '%s', an error was thrown:\n%s`,
+
+    UnrecognizableJavaVersion:
+        `The command '%s' does not seem to be a recognizable version of Java.`,
+
+    JavaBelowMinimumVersion:
+        `The command '%s' specifies Java v%s, which is below minimum supported version v%s.`,
+
+    CouldNotLocateJava:
+        `Could not locate Java v%s+.\n` +
+        `%s\n` +
+        `If you have Java installed, specify the command in your Code Analyzer configuration as the value of property '%s'.\n` +
+        `If you choose not to install Java, you may disable the corresponding engine in your Code Analyzer configuration by setting '%s' to true.`,
 
     WorkspaceAppearsIncomplete:
         `Specified workspace is missing %d possibly-relevant file(s) from the folder %s. Salesforce Graph Engine may be unable to create a complete graph of your project without all apex files included in your workspace. This may result in incomplete or incorrect results.`,

--- a/packages/code-analyzer-sfge-engine/src/plugin.ts
+++ b/packages/code-analyzer-sfge-engine/src/plugin.ts
@@ -12,11 +12,14 @@ import {
 } from "./config";
 import {getMessage} from './messages';
 import {SfgeEngine} from "./engine";
+import {JavaVersionIdentifier, RuntimeJavaVersionIdentifier} from "./java-version-identifier";
 
 export class SfgeEnginePlugin extends EnginePluginV1 {
+    private readonly javaVersionIdentifier: JavaVersionIdentifier;
 
-    public constructor() {
+    public constructor(javaVersionIdentifier: JavaVersionIdentifier = new RuntimeJavaVersionIdentifier()) {
         super();
+        this.javaVersionIdentifier = javaVersionIdentifier;
     }
 
     public override getAvailableEngineNames(): string[] {
@@ -30,7 +33,7 @@ export class SfgeEnginePlugin extends EnginePluginV1 {
 
     public override async createEngineConfig(engineName: string, configValueExtractor: ConfigValueExtractor): Promise<ConfigObject> {
         validateEngineName(engineName);
-        return await validateAndNormalizeConfig(configValueExtractor) as ConfigObject;
+        return await validateAndNormalizeConfig(configValueExtractor, this.javaVersionIdentifier) as ConfigObject;
     }
 
     public override async createEngine(engineName: string, resolvedConfig: ConfigObject): Promise<Engine> {

--- a/packages/code-analyzer-sfge-engine/test/java-version-identifier.test.ts
+++ b/packages/code-analyzer-sfge-engine/test/java-version-identifier.test.ts
@@ -1,0 +1,41 @@
+import {SemVer} from "semver";
+import {_extractJavaVersionFrom} from "../src/java-version-identifier";
+
+describe('Test for _extractJavaVersionFrom helper', () => {
+    type VERSION_CASE = {description: string, input: string, expected: SemVer};
+    const versionCases: VERSION_CASE[] = [
+        {
+            description: 'v11_linux',
+            input: 'openjdk version "11.0.6" 2020-01-14 LTS\nOpenJDK Runtime Environment Zulu11.37+17-CA (build 11.0.6+10-LTS)\nOpenJDK 64-Bit Server VM Zulu11.37+17-CA (build 11.0.6+10-LTS, mixed mode)\n',
+            expected: new SemVer('11.0.6')
+        },
+        {
+            description: 'v8_mac',
+            input: 'openjdk version "1.8.0_172"\nOpenJDK Runtime Environment (Zulu 8.30.0.2-macosx) (build 1.8.0_172-b01)\nOpenJDK 64-Bit Server VM (Zulu 8.30.0.2-macosx) (build 25.172-b01, mixed mode)\n',
+            expected: new SemVer('1.8.0')
+        },
+        {
+            description: 'v12_linux',
+            input: 'java version "12.0.1" 2019-04-16\nJava(TM) SE Runtime Environment (build 12.0.1+12)\nJava HotSpot(TM) 64-Bit Server VM (build 12.0.1+12, mixed mode, sharing)',
+            expected: new SemVer('12.0.1')
+        },
+        { // This comes from https://github.com/forcedotcom/sfdx-scanner/issues/1453
+            description: 'v17_with_java_options',
+            input: 'Picked up _JAVA_OPTIONS: -Xmx5g\njava version "17.0.11" 2024-04-16 LTS\nJava(TM) SE Runtime Environment (build 17.0.11+7-LTS-207)',
+            expected: new SemVer('17.0.11')
+        },
+        { // This type of output typically comes from "java --version" instead of "java -version" but we will try to support it as well
+            description: 'v14_windows',
+            input: 'openjdk 14 2020-03-17\r\nOpenJDK Runtime Environment (build 14+36-1461)\r\nOpenJDK 64-Bit Server VM (build 14+36-1461, mixed mode, sharing)\r\n',
+            expected: new SemVer('14.0.0')
+        }
+    ];
+    it.each(versionCases)('For version $description, make sure _extractJavaVersionFrom returns expected version', async (caseObj: VERSION_CASE) => {
+        const version: SemVer = _extractJavaVersionFrom(caseObj.input)!;
+        expect(version.toString()).toEqual(caseObj.expected.toString());
+    });
+
+    it('Check that _extractJavaVersionFrom returns null if given garbage without version info', async () => {
+        expect(_extractJavaVersionFrom('this is garbage')).toEqual(null);
+    });
+});

--- a/packages/code-analyzer-sfge-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-sfge-engine/test/plugin.test.ts
@@ -5,6 +5,7 @@ import {
     getMessageFromCatalog,
     SHARED_MESSAGE_CATALOG
 } from "@salesforce/code-analyzer-engine-api";
+import {SemVer} from 'semver';
 import {SfgeEnginePlugin} from "../src";
 import {
     DEFAULT_SFGE_ENGINE_CONFIG,
@@ -13,6 +14,7 @@ import {
 } from "../src/config";
 import {SfgeEngine} from "../src/engine";
 import {getMessage} from '../src/messages';
+import {JavaVersionIdentifier, RuntimeJavaVersionIdentifier} from "../src/java-version-identifier";
 
 describe('SfgeEnginePlugin', () => {
     let plugin: EnginePluginV1;
@@ -45,7 +47,7 @@ describe('SfgeEnginePlugin', () => {
             const cve: ConfigValueExtractor = new ConfigValueExtractor({invalidField: 2}, 'engines.sfge');
             await expect(plugin.createEngineConfig('sfge', cve)).rejects.toThrow(
                 getMessageFromCatalog(SHARED_MESSAGE_CATALOG, 'ConfigObjectContainsInvalidKey', 'engines.sfge', 'invalidField',
-                    '["disable_limit_reached_violations","java_max_heap_size","java_thread_count","java_thread_timeout"]'));
+                    '["disable_limit_reached_violations","java_command","java_max_heap_size","java_thread_count","java_thread_timeout"]'));
         });
 
         it('When given an empty raw config, the correct defaults are returned', async () => {
@@ -53,9 +55,9 @@ describe('SfgeEnginePlugin', () => {
             // This test assumes that all environments that run this test will have JAVA v11+ installed and either has
             // * the JAVA_HOME environment variable points to the home folder of this java command
             // * or has the java command is already on the top of the PATH
-            //expect(resolvedConfig.java_command.endsWith('java')).toEqual(true);
+            expect(resolvedConfig.java_command.endsWith('java')).toEqual(true);
             expect(resolvedConfig).toEqual({
-                //java_command: resolvedConfig.java_command, // We just checked the Java Command above.
+                java_command: resolvedConfig.java_command, // We just checked the Java Command above.
                 disable_limit_reached_violations: false,
                 java_max_heap_size: undefined,
                 java_thread_count: 4,
@@ -63,25 +65,63 @@ describe('SfgeEnginePlugin', () => {
             });
         });
 
-//        describe(`Validating the pathlike 'java_command' property`, () => {
-//            it.each([
-//                {case: 'Java lookup fails'},
-//                {case: 'Java lookup produces outdated Java version'}
-//            ])('When java_command is absent and $case, an error is thrown', async () => {
-//
-//            });
-//
-//            it.each([
-//                {case: 'invalid'},
-//                {case: 'outdated'}
-//            ])('When provided java_command value is $case, an error is thrown', async () => {
-//
-//            });
-//
-//            it('When provided java_command value is valid and up-to-date, it is used', async () => {
-//
-//            });
-//        });
+        describe(`Validating the pathlike 'java_command' property`, () => {
+            it.each([
+                {
+                    case: 'absent and Java lookup fails',
+                    configObject: {} as ConfigObject,
+                    javaVersionIdentifierBuilder: () => new StubJavaVersionIdentifier(null),
+                    mainMessage: 'Could not locate Java v11.0.0+',
+                    reasonMessage: getMessage('UnrecognizableJavaVersion', 'java')
+                },
+                {
+                    case: 'absent and Java lookup produces outdated Java version',
+                    configObject: {} as ConfigObject,
+                    javaVersionIdentifierBuilder: () => new StubJavaVersionIdentifier(new SemVer('1.9.0')),
+                    mainMessage: 'Could not locate Java v11.0.0+',
+                    reasonMessage: `The command 'java' specifies Java v1.9.0, which is below minimum supported version v11.0.0.`
+                },
+                {
+                    case: 'specified as an invalid command',
+                    configObject: {java_command: '/some/invalid/java'} as ConfigObject,
+                    javaVersionIdentifierBuilder: () => new RuntimeJavaVersionIdentifier(),
+                    mainMessage: `The 'engines.sfge.java_command' configuration value is invalid.`,
+                    reasonMessage: `When attempting to find the version of command '/some/invalid/java', an error was thrown:`
+                },
+                {
+                    case: 'specified as an unrecognizable version',
+                    configObject: {java_command: '/some/version/of/java'} as ConfigObject,
+                    javaVersionIdentifierBuilder: () => new StubJavaVersionIdentifier(null),
+                    mainMessage: `The 'engines.sfge.java_command' configuration value is invalid.`,
+                    reasonMessage: getMessage('UnrecognizableJavaVersion', '/some/version/of/java')
+                },
+                {
+                    case: 'specified as an outdated version',
+                    configObject: {java_command: '/some/version/of/java'} as ConfigObject,
+                    javaVersionIdentifierBuilder: () => new StubJavaVersionIdentifier(new SemVer('1.9.0')),
+                    mainMessage: `The 'engines.sfge.java_command' configuration value is invalid.`,
+                    reasonMessage: `The command '/some/version/of/java' specifies Java v1.9.0, which is below minimum supported version v11.0.0.`,
+                }
+            ])('When java_command is $case, an error is thrown', async ({configObject, javaVersionIdentifierBuilder, mainMessage, reasonMessage}) => {
+                const pluginWithStub: SfgeEnginePlugin = new SfgeEnginePlugin(javaVersionIdentifierBuilder());
+                try {
+                    await pluginWithStub.createEngineConfig('sfge', new ConfigValueExtractor(configObject, 'engines.sfge'));
+                    fail('Expected error to be thrown');
+                } catch (err) {
+                    const errMsg: string = (err as Error).message;
+                    expect(errMsg).toContain(mainMessage);
+                    expect(errMsg).toContain(reasonMessage);
+                }
+            });
+
+            it('When provided java_command value is valid and up-to-date, it is used', async () => {
+                const pluginWithStub: SfgeEnginePlugin = new SfgeEnginePlugin(new StubJavaVersionIdentifier(new SemVer('21.4.0')));
+                const rawConfig: ConfigObject = {java_command: '/some/java'};
+                const configValueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.sfge');
+                const normalizedConfig: ConfigObject = await pluginWithStub.createEngineConfig('sfge', configValueExtractor);
+                expect(normalizedConfig).toHaveProperty('java_command', '/some/java');
+            });
+        });
 
         describe(`Validating the boolean 'disable_limit_reached_violations' property`, () => {
             it.each([
@@ -233,3 +273,15 @@ describe('SfgeEnginePlugin', () => {
         });
     });
 });
+
+class StubJavaVersionIdentifier implements JavaVersionIdentifier {
+    private readonly version: SemVer|null;
+
+    constructor(version: SemVer|null) {
+        this.version = version;
+    }
+
+    public identifyJavaVersion(_javaCommand: string): Promise<SemVer|null> {
+        return Promise.resolve(this.version);
+    }
+}


### PR DESCRIPTION
This PR implements the `java_command` config property in SFGE. It is the follow-up to #243, which implemented all of the other SFGE config properties except for `java_command`.

The implementation is more-or-less a copy-paste of the implementation in the PMD/CPD engine. This was done for simplicity and time, and it is highly likely that we will refactor the common code from the implementation into a shared space that both plugins can access, to minimize duplication.