### PR TITLE
CHANGE: @W-18034818@ github action update for flowtest removal

### DIFF
--- a/.github/workflows/verify-pr/validate-changed-package-versions.js
+++ b/.github/workflows/verify-pr/validate-changed-package-versions.js
@@ -70,6 +70,10 @@ function isFileInTestFolder(changedFile) {
 function identifyIncorrectlyVersionedPackages(changedPackages) {
     const incorrectlyVersionedPackages = [];
     for (const changedPackage of changedPackages) {
+        //A temporary workaround for the rename of the flowtest-engine package to flow-engine
+        if (changedPackage === 'packages/code-analyzer-flowtest-engine') {
+            continue;
+        }
         const packageVersion = getPackageVersion(changedPackage);
         if (!packageVersion.endsWith('-SNAPSHOT')) {
             incorrectlyVersionedPackages.push(`${changedPackage} (currently versioned as ${packageVersion}) lacks a trailing "-SNAPSHOT"`);


### PR DESCRIPTION
This temporary adjustment is to accommodate the failing github action failing with #248. The action is checking for the version of the package under "packages/code-analyzer-flowtest-engine", since files with that named are seen to have changed. But in this case, we need to skip the check for these changed files since that package does not persist under the same name.