### PR TITLE
NEW: @W-18095617@ File Targeting for Flow Engine

### DIFF
--- a/packages/code-analyzer-flow-engine/src/engine.ts
+++ b/packages/code-analyzer-flow-engine/src/engine.ts
@@ -34,7 +34,7 @@ export class FlowScannerEngine extends Engine {
 
     public constructor(commandWrapper: FlowScannerCommandWrapper, clock: Clock = new RealClock()) {
         super();
-        this.commandWrapper =  commandWrapper;
+        this.commandWrapper = commandWrapper;
         this.clock = clock;
     }
 
@@ -64,8 +64,8 @@ export class FlowScannerEngine extends Engine {
 
     public async runRules(ruleNames: string[], runOptions: RunOptions): Promise<EngineRunResults> {
         this.emitRunRulesProgressEvent(0);
-        const relevantFiles: string[] = await this.getRelevantFiles(runOptions.workspace);
-        if (relevantFiles.length == 0) {
+        const allFlowsInWorkspace: string[] = await this.getRelevantFiles(runOptions.workspace);
+        if (allFlowsInWorkspace.length == 0) {
             return { violations: [] };
         }
 
@@ -76,22 +76,32 @@ export class FlowScannerEngine extends Engine {
         this.emitRunRulesProgressEvent(PRE_INVOCATION_RUN_PERCENT);
         const percentageUpdateHandler = /* istanbul ignore next */ (percentage: number) => {
             this.emitRunRulesProgressEvent(normalizeRelativeCompletionPercentage(percentage));
-        }
+        };
 
-        // TODO: Note that currently we are only passing to flow scanner the targeted files, but ideally we should
-        // be passing in the relevant workspace files to be the search area from which flow scanner may look for sub flows
-        // while we still pass in the targeted flow files.
+        // TODO: Note that we are passing to flow scanner all of the workspace files, but ideally we should
+        // be passing in the relevant workspace files AND targeted files so we don't have to filter out
+        // execution results for targeted files in post-processing
         const executionResults: FlowScannerExecutionResult = await this.commandWrapper.runFlowScannerRules(
-            relevantFiles, logFile, percentageUpdateHandler);
-        const convertedResults: EngineRunResults = toEngineRunResults(executionResults, ruleNames);
+            allFlowsInWorkspace,
+            logFile,
+            percentageUpdateHandler
+        );
+
+        const targetedFiles = await runOptions.workspace.getTargetedFiles();
+        const convertedResults: EngineRunResults = toEngineRunResults(executionResults, ruleNames, targetedFiles);
         this.emitRunRulesProgressEvent(100);
         return convertedResults;
     }
 
+    /**
+     * Gets all of the flow files in the workspace or the cached files if available
+     * @param workspace
+     * @returns a list of file names
+     */
     private async getRelevantFiles(workspace: Workspace): Promise<string[]> {
         const cacheKey: string = workspace.getWorkspaceId();
         if (!this.relevantFilesCache.has(cacheKey)) {
-            const relevantFiles: string[] = (await workspace.getTargetedFiles()).filter(fileIsFlowFile);
+            const relevantFiles: string[] = (await workspace.getWorkspaceFiles()).filter(fileIsFlowFile);
             this.relevantFilesCache.set(cacheKey, relevantFiles);
         }
         return this.relevantFilesCache.get(cacheKey)!;
@@ -114,7 +124,11 @@ function normalizeRelativeCompletionPercentage(flowPercentage: number): number {
     return PRE_INVOCATION_RUN_PERCENT + ((flowPercentage * percentageSpread) / 100);
 }
 
-function toEngineRunResults(flowScannerExecutionResult: FlowScannerExecutionResult, requestedRules: string[]): EngineRunResults {
+function toEngineRunResults(
+    flowScannerExecutionResult: FlowScannerExecutionResult,
+    requestedRules: string[],
+    requestedFiles: string[]
+): EngineRunResults {
     const requestedRulesSet: Set<string> = new Set(requestedRules);
     const results: EngineRunResults = {
         violations: []
@@ -129,14 +143,19 @@ function toEngineRunResults(flowScannerExecutionResult: FlowScannerExecutionResu
             if (!requestedRulesSet.has(ruleName)) {
                 continue;
             }
-            const flowNodes: FlowNodeDescriptor[] = flowScannerRuleResult.flow;
-            results.violations.push({
-                ruleName,
-                message: flowScannerRuleResult.description,
-                codeLocations: toCodeLocationList(flowNodes),
-                primaryLocationIndex: flowScannerRuleResult.flow.length - 1,
-                resourceUrls: []
-            });
+            const flowNodes: FlowNodeDescriptor[] = getNodesForTargetedFlows(
+                flowScannerRuleResult.flow,
+                requestedFiles
+            );
+            if (flowNodes.length > 0) {
+                results.violations.push({
+                    ruleName,
+                    message: flowScannerRuleResult.description,
+                    codeLocations: toCodeLocationList(flowNodes),
+                    primaryLocationIndex: flowScannerRuleResult.flow.length - 1,
+                    resourceUrls: []
+                });
+            }
         }
     }
     return results;
@@ -159,4 +178,15 @@ function toCodeLocationList(flowNodes: FlowNodeDescriptor[]): CodeLocation[] {
         previousFullVariable = fullVariable;
     }
     return results;
+}
+
+/**
+ * Workaround function to only return targeted flow results if there were targeted files
+ */
+function getNodesForTargetedFlows(allFlowNodes: FlowNodeDescriptor[], requestedFiles: string[]): FlowNodeDescriptor[] {
+    if (requestedFiles.length === 0) {
+        return allFlowNodes;
+    }
+    const requestedFilesSet: Set<string> = new Set(requestedFiles);
+    return allFlowNodes.filter((node) => requestedFilesSet.has(node.flow_path));
 }

--- a/packages/code-analyzer-flow-engine/test/engine.test.ts
+++ b/packages/code-analyzer-flow-engine/test/engine.test.ts
@@ -32,6 +32,7 @@ const PATH_TO_EXAMPLE2: string = path.join(PATH_TO_MULTIPLE_FLOWS_WORKSPACE, 'ex
 const PATH_TO_EXAMPLE3: string = path.join(PATH_TO_MULTIPLE_FLOWS_WORKSPACE, 'example3_containsNoViolations.flow');
 const PATH_TO_EXAMPLE4_PARENTFLOW: string = path.join(PATH_TO_MULTIPLE_FLOWS_WORKSPACE, 'example4_parentFlow.flow-meta.xml');
 const PATH_TO_EXAMPLE4_SUBFLOW: string = path.join(PATH_TO_MULTIPLE_FLOWS_WORKSPACE, 'example4_subflow.flow-meta.xml');
+const PATH_TO_EXAMPLE5: string = path.join(PATH_TO_MULTIPLE_FLOWS_WORKSPACE, 'shouldNotGetPickedUpByFlowScanner.xml');
 
 describe('Tests for the TestEngine', () => {
     const flowScannerCommandWrapper: RunTimeFlowScannerCommandWrapper = new RunTimeFlowScannerCommandWrapper('python3');
@@ -466,6 +467,70 @@ describe('Tests for the TestEngine', () => {
 
                 const engineResults1: EngineRunResults = await engine.runRules(selectedRuleNames, createRunOptions(tempFolder, workspace));
                 expect(engineResults1.violations).toHaveLength(0);
+            });
+
+            it("When no targeted files have violations but non-targeted files do, then no violations are returned.", async () => {
+                const engine: FlowScannerEngine = new FlowScannerEngine(flowScannerCommandWrapper);
+
+                const selectedRuleNames: string[] = [
+                    "PreventPassingUserDataIntoElementWithSharing",
+                    "PreventPassingUserDataIntoElementWithoutSharing"
+                ];
+
+                const engineResults: EngineRunResults = await engine.runRules(
+                    selectedRuleNames,
+                    createRunOptions(tempFolder, new Workspace("id", [PATH_TO_MULTIPLE_FLOWS_WORKSPACE], [PATH_TO_EXAMPLE3]))
+                );
+
+                expect(engineResults.violations).toHaveLength(0);
+            });
+
+            it("When only non-flow files are targeted in a workspace with violations, then no violations are returned.", async () => {
+                const engine: FlowScannerEngine = new FlowScannerEngine(flowScannerCommandWrapper);
+
+                const selectedRuleNames: string[] = [
+                    "PreventPassingUserDataIntoElementWithSharing",
+                    "PreventPassingUserDataIntoElementWithoutSharing"
+                ];
+
+                const engineResults: EngineRunResults = await engine.runRules(
+                    selectedRuleNames,
+                    createRunOptions(tempFolder, new Workspace("id", [PATH_TO_MULTIPLE_FLOWS_WORKSPACE], [PATH_TO_EXAMPLE5]))
+                );
+
+                expect(engineResults.violations).toHaveLength(0);
+            });
+
+            it("When both targeted files and non-targeted files have violations, then only the violations for the targeted files are returned.", async () => {
+                const engine: FlowScannerEngine = new FlowScannerEngine(flowScannerCommandWrapper);
+
+                const selectedRuleNames: string[] = [
+                    "PreventPassingUserDataIntoElementWithSharing",
+                    "PreventPassingUserDataIntoElementWithoutSharing"
+                ];
+
+                const engineResults: EngineRunResults = await engine.runRules(
+                    selectedRuleNames,
+                    createRunOptions(tempFolder, new Workspace("id", [PATH_TO_MULTIPLE_FLOWS_WORKSPACE], [PATH_TO_EXAMPLE1]))
+                );
+
+                expect(engineResults.violations).toHaveLength(2);
+            });
+
+            it("When all files in a workspace are targeted and have violations, all of the violations are returned.", async () => {
+                const engine: FlowScannerEngine = new FlowScannerEngine(flowScannerCommandWrapper);
+
+                const selectedRuleNames: string[] = [
+                    "PreventPassingUserDataIntoElementWithSharing",
+                    "PreventPassingUserDataIntoElementWithoutSharing"
+                ];
+
+                const engineResults: EngineRunResults = await engine.runRules(
+                    selectedRuleNames,
+                    createRunOptions(tempFolder, new Workspace("id", [PATH_TO_EXAMPLE1], [PATH_TO_EXAMPLE1]))
+                );
+
+                expect(engineResults.violations).toHaveLength(2);
             });
 
             // TODO: Add in tests for case of scanning 2 folders with the exact same flows.


### PR DESCRIPTION
Respects the option of targeted files by adding a check to `getTargetedFiles` on the workspace. If files are targeted, the engine filters out any irrelevant file execution data in post-processing.

This change ensures that the Flow Engine is aware of all of the workspace files during processing, so that rules can be aware of the relationships between all flows. This also means the engine scans all flows during each flow execution.

In a future version, this work should ideally be done by the python module and we can make an update to pass in both the workspace and the targeted files to it. For now the experience for the user should be the same since the Flow Engine runs quickly enough that latency should not be an issue.