### PR TITLE
CHANGE @W-18292873@ Modularized release branch creation script

### DIFF
--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -138,101 +138,14 @@ jobs:
           npm run build
           # No need to test; that comes later.
       - name: Commit changes to release branch
+        shell: zsh {0}
         run: |
-          # GraphQL needs to know what branch to push to.
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          # GraphQL needs a message for the commit.
-          MESSAGE="Preparing Core Ecosystem for release"
-          # GraphQL needs the latest versions of all the package.json files, as Base64 encoded strings.
-          CORE_PACKAGE_JSON="$(cat packages/code-analyzer-core/package.json | base64)"
-          API_PACKAGE_JSON="$(cat packages/code-analyzer-engine-api/package.json | base64)"
-          ESLINT_PACKAGE_JSON="$(cat packages/code-analyzer-eslint-engine/package.json | base64)"
-          FLOW_PACKAGE_JSON="$(cat packages/code-analyzer-flow-engine/package.json | base64)"
-          PMD_PACKAGE_JSON="$(cat packages/code-analyzer-pmd-engine/package.json | base64)"
-          REGEX_PACKAGE_JSON="$(cat packages/code-analyzer-regex-engine/package.json | base64)"
-          RETIREJS_PACKAGE_JSON="$(cat packages/code-analyzer-retirejs-engine/package.json | base64)"
-          SFGE_PACKAGE_JSON="$(cat packages/code-analyzer-sfge-engine/package.json | base64)"
-          STYLELINT_PACKAGE_JSON="$(cat packages/code-analyzer-stylelint-engine/package.json | base64)"
-          ENGINE_TEMPLATE_PACKAGE_JSON="$(cat packages/ENGINE-TEMPLATE/package.json | base64)"
-          TEMPLATE_PACKAGE_JSON="$(cat packages/T-E-M-P-L-A-T-E/package.json | base64)"
-          # GraphQL also needs the top-level package-lock.json
-          PACKAGE_LOCK_JSON="$(cat package-lock.json | base64)"
-
-          gh api graphql -F message="$MESSAGE" -F oldOid=`git rev-parse HEAD` -F branch="$BRANCH_NAME" \
-          -F corePackage="$CORE_PACKAGE_JSON" \
-          -F apiPackage="$API_PACKAGE_JSON" \
-          -F eslintPackage="$ESLINT_PACKAGE_JSON" \
-          -F flowPackage="$FLOW_PACKAGE_JSON" \
-          -F pmdPackage="$PMD_PACKAGE_JSON" \
-          -F regexPackage="$REGEX_PACKAGE_JSON" \
-          -F retirejsPackage="$RETIREJS_PACKAGE_JSON" \
-          -F sfgePackage="$SFGE_PACKAGE_JSON" \
-          -F stylelintPackage="$STYLELINT_PACKAGE_JSON" \
-          -F engineTemplatePackage="$ENGINE_TEMPLATE_PACKAGE_JSON" \
-          -F templatePackage="$TEMPLATE_PACKAGE_JSON" \
-          -F packageLock="$PACKAGE_LOCK_JSON" \
-          -f query='
-            mutation ($message: String!, $oldOid: GitObjectID!, $branch: String!,
-                      $corePackage: Base64String!, $apiPackage: Base64String!, $eslintPackage: Base64String!,
-                      $flowPackage: Base64String!, $pmdPackage: Base64String!, $regexPackage: Base64String!,
-                      $retirejsPackage: Base64String!, $sfgePackage: Base64String!, $stylelintPackage: Base64String!,
-                      $engineTemplatePackage: Base64String!, $templatePackage: Base64String!, $packageLock: Base64String!) {
-              createCommitOnBranch(input: {
-                branch: {
-                  repositoryNameWithOwner: "forcedotcom/code-analyzer-core",
-                  branchName: $branch
-                },
-                message: {
-                  headline: $message
-                },
-                fileChanges: {
-                  additions: [
-                    {
-                      path: "packages/code-analyzer-core/package.json",
-                      contents: $corePackage
-                    }, {
-                      path: "packages/code-analyzer-engine-api/package.json",
-                      contents: $apiPackage
-                    }, {
-                      path: "packages/code-analyzer-eslint-engine/package.json",
-                      contents: $eslintPackage
-                    }, {
-                      path: "packages/code-analyzer-flow-engine/package.json",
-                      contents: $flowPackage
-                    }, {
-                      path: "packages/code-analyzer-pmd-engine/package.json",
-                      contents: $pmdPackage
-                    }, {
-                      path: "packages/code-analyzer-regex-engine/package.json",
-                      contents: $regexPackage
-                    }, {
-                      path: "packages/code-analyzer-retirejs-engine/package.json",
-                      contents: $retirejsPackage
-                    }, {
-                      path: "packages/code-analyzer-sfge-engine/package.json",
-                      contents: $sfgePackage
-                    }, {
-                      path: "packages/code-analyzer-stylelint-engine/package.json",
-                      contents: $stylelintPackage
-                    }, {
-                      path: "packages/ENGINE-TEMPLATE/package.json",
-                      contents: $engineTemplatePackage
-                    }, {
-                      path: "packages/T-E-M-P-L-A-T-E/package.json",
-                      contents: $templatePackage
-                    }, {
-                      path: "package-lock.json",
-                      contents: $packageLock
-                    }
-                  ]
-                },
-                expectedHeadOid: $oldOid
-              }) {
-                commit {
-                  id
-                }
-              }
-            }'
+          cd packages
+          ALL_PACKAGES=`ls`
+          cd ..
+          node ./.github/workflows/publish-package-to-npm/create-branch-commit-script.js "$ALL_PACKAGES"
+          SCRIPT=`cat graphQlScript.txt`
+          eval $SCRIPT
   build-and-test-and-publish:
     runs-on: ubuntu-latest
     needs: [validate-packages-as-releasable, prepare-release-branch]

--- a/.github/workflows/publish-package-to-npm/create-branch-commit-script.js
+++ b/.github/workflows/publish-package-to-npm/create-branch-commit-script.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+
+function main() {
+    // Split on `\n` instead of ` ` because this argument comes from $(ls).
+    const packageNames = process.argv[2].split("\n");
+
+    const scriptLines = [];
+    scriptLines.push(`BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)`);
+    scriptLines.push(`MESSAGE="Preparing Core Ecosystem for release"`);
+    scriptLines.push(...generatePackageVarDeclarations(packageNames));
+    scriptLines.push(`PACKAGE_LOCK="$(cat package-lock.json | base64)"`);
+    scriptLines.push('');
+    scriptLines.push('gh api graphql -F message="$MESSAGE" -F oldOid=\`git rev-parse HEAD\` -F branch="$BRANCH_NAME" \\');
+    scriptLines.push(...generateGraphQlDashFFlagsForPackages(packageNames));
+    scriptLines.push(`-F packagelock="$PACKAGE_LOCK" \\`);
+    scriptLines.push(`-f query='`);
+    scriptLines.push(`  mutation (${createMutationParameters(packageNames).join(', ')}) {`);
+    scriptLines.push(`    createCommitOnBranch(input: {`);
+    scriptLines.push(`      branch: {`);
+    scriptLines.push(`        repositoryNameWithOwner: "forcedotcom/code-analyzer-core",`);
+    scriptLines.push(`        branchName: $branch`);
+    scriptLines.push(`      },`);
+    scriptLines.push(`      message: {`);
+    scriptLines.push(`        headline: $message`);
+    scriptLines.push(`      },`);
+    scriptLines.push(`      fileChanges: {`);
+    scriptLines.push(`        additions: [`);
+    scriptLines.push(`          {`);
+    scriptLines.push(createAdditionsArray(packageNames).join('          }, {\n'));
+    scriptLines.push(`          }`);
+    scriptLines.push(`        ]`);
+    scriptLines.push(`      },`);
+    scriptLines.push(`      expectedHeadOid: $oldOid`);
+    scriptLines.push(`    }) {`);
+    scriptLines.push(`      commit {`);
+    scriptLines.push(`        id`);
+    scriptLines.push(`      }`);
+    scriptLines.push(`    }`);
+    scriptLines.push(`  }'`);
+
+    const script = scriptLines.join('\n');
+
+    console.log(`========= WRITING THIS SCRIPT TO FILE =======`);
+    console.log(script);
+
+    fs.writeFileSync('graphQlScript.txt', script);
+}
+
+function generatePackageVarDeclarations(packageNames) {
+    const packageVarDeclarations = [];
+    for (const packageName of packageNames) {
+        packageVarDeclarations.push(`${toPackageVarName(packageName)}="$(cat packages/${packageName}/package.json | base64)"`);
+    }
+    return packageVarDeclarations;
+}
+
+function generateGraphQlDashFFlagsForPackages(packageNames) {
+    const dashFFlags = [];
+    for (const packageName of packageNames) {
+        dashFFlags.push(`-F ${toMutationParamName(packageName)}="$${toPackageVarName(packageName)}" \\`);
+    }
+    return dashFFlags;
+}
+
+function createMutationParameters(packageNames) {
+    const mutationParameters = [];
+    mutationParameters.push('$message: String!');
+    mutationParameters.push('$oldOid: GitObjectID!');
+    mutationParameters.push('$branch: String!');
+    for (const packageName of packageNames) {
+        mutationParameters.push(`$${toMutationParamName(packageName)}: Base64String!`);
+    }
+    mutationParameters.push(`$packagelock: Base64String!`);
+    return mutationParameters;
+}
+
+function createAdditionsArray(packageNames) {
+    const additions = [];
+    for (const packageName of packageNames) {
+        additions.push(
+            `            path: "packages/${packageName}/package.json",\n` +
+            `            contents: $${toMutationParamName(packageName)}\n`
+        );
+    }
+    additions.push(
+        `            path: "package-lock.json",\n` +
+        `            contents: $packagelock`
+    );
+    return additions;
+}
+
+function toPackageVarName(packageName) {
+    return packageName.toUpperCase().replaceAll('-', '_');
+}
+
+function toMutationParamName(packageName) {
+    return packageName.toLowerCase().replaceAll('-', '');
+}
+
+main();


### PR DESCRIPTION
This PR does the following:
- Replaces a script in `publish-package-to-npm.yml` that previously needed to be manually updated with every new engine with a JS file that dynamically generates an equivalent script encompassing all packages.

For an example and proof of concept, see #256 , which was able to successfully create [this branch](https://github.com/forcedotcom/code-analyzer-core/tree/experiment/1744833961) and add a commit updating all of the `package.json` files as appropriate.