### PR TITLE
NEW @W-17915999@ Implemented engine-level telemetry framework.

### DIFF
--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -16,8 +16,7 @@ import {
     Event,
     EventType,
     LogLevel,
-    TelemetryData,
-    TelemetryEvent
+    TelemetryData
 } from "./events"
 import {getMessage} from "./messages";
 import * as engApi from "@salesforce/code-analyzer-engine-api"
@@ -400,12 +399,14 @@ export class CodeAnalyzer {
         })
     }
 
+    // This method is currently unused, so no coverage is possible. However, it's going to be used very shortly, so we're
+    // adding it now and just disabling the coverage check for it.
     // istanbul ignore next
     private emitTelemetryEvent(eventName: string, data: TelemetryData): void {
         this.emitEvent({
             type: EventType.TelemetryEvent,
             timestamp: this.clock.now(),
-            eventName,
+            eventName,k
             uuid: this.uniqueIdGenerator.getUniversallyUniqueId(),
             data
         });

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -406,7 +406,7 @@ export class CodeAnalyzer {
         this.emitEvent({
             type: EventType.TelemetryEvent,
             timestamp: this.clock.now(),
-            eventName,k
+            eventName,
             uuid: this.uniqueIdGenerator.getUniversallyUniqueId(),
             data
         });

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -469,7 +469,7 @@ export class CodeAnalyzer {
                 timestamp: this.clock.now(),
                 engineName: engine.getName(),
                 type: EventType.EngineTelemetryEvent,
-                key: event.key,
+                eventName: event.eventName,
                 data: event.data
             });
         });

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -22,7 +22,7 @@ import * as engApi from "@salesforce/code-analyzer-engine-api"
 import {Clock, RealClock} from '@salesforce/code-analyzer-engine-api/utils';
 import {EventEmitter} from "node:events";
 import {CodeAnalyzerConfig, ConfigDescription, EngineOverrides, FIELDS, RuleOverride} from "./config";
-import {EngineProgressAggregator, SimpleUniqueIdGenerator, toAbsolutePath, UniqueIdGenerator} from "./utils";
+import {EngineProgressAggregator, RuntimeUniqueIdGenerator, toAbsolutePath, UniqueIdGenerator} from "./utils";
 import fs from "node:fs";
 import path from 'node:path';
 
@@ -92,7 +92,7 @@ const MINIMUM_SUPPORTED_NODE = 20;
 export class CodeAnalyzer {
     private readonly config: CodeAnalyzerConfig;
     private clock: Clock = new RealClock();
-    private uniqueIdGenerator: UniqueIdGenerator = new SimpleUniqueIdGenerator();
+    private uniqueIdGenerator: UniqueIdGenerator = new RuntimeUniqueIdGenerator();
     private readonly eventEmitter: EventEmitter = new EventEmitter();
     private readonly engines: Map<string, engApi.Engine> = new Map();
     private readonly uninstantiableEnginesMap: Map<string, Error> = new Map();
@@ -143,7 +143,7 @@ export class CodeAnalyzer {
      * @param targets optional string array of files and/or folders
      */
     public async createWorkspace(workspaceFilesAndFolders: string[], targets?: string[]): Promise<Workspace> {
-        const workspaceId: string = this.uniqueIdGenerator.getUniqueId('workspace');
+        const workspaceId: string = this.uniqueIdGenerator.getLocallyUniqueId('workspace');
         const workspaceValidationPromises: Promise<string>[] = workspaceFilesAndFolders.map(validateFileOrFolder);
         const validatedWorkspaceFilesAndFolders: string[] = (await Promise.all(workspaceValidationPromises)).flat();
         if (validatedWorkspaceFilesAndFolders.length === 0) {
@@ -470,6 +470,7 @@ export class CodeAnalyzer {
                 engineName: engine.getName(),
                 type: EventType.EngineTelemetryEvent,
                 eventName: event.eventName,
+                uuid: this.uniqueIdGenerator.getUniversallyUniqueId(),
                 data: event.data
             });
         });

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -15,7 +15,9 @@ import {
     EngineTelemetryEvent,
     Event,
     EventType,
-    LogLevel
+    LogLevel,
+    TelemetryData,
+    TelemetryEvent
 } from "./events"
 import {getMessage} from "./messages";
 import * as engApi from "@salesforce/code-analyzer-engine-api"
@@ -396,6 +398,17 @@ export class CodeAnalyzer {
             logLevel: logLevel,
             message: message
         })
+    }
+
+    // istanbul ignore next
+    private emitTelemetryEvent(eventName: string, data: TelemetryData): void {
+        this.emitEvent({
+            type: EventType.TelemetryEvent,
+            timestamp: this.clock.now(),
+            eventName,
+            uuid: this.uniqueIdGenerator.getUniversallyUniqueId(),
+            data
+        });
     }
 
     private async createAndAddEngineIfValid(engineName: string, enginePluginV1: engApi.EnginePluginV1): Promise<void> {

--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -8,18 +8,21 @@ import {
     UninstantiableEngineRunResults
 } from "./results"
 import {SemVer} from 'semver';
-import {EngineLogEvent, EngineResultsEvent, EngineRunProgressEvent, Event, EventType, LogLevel} from "./events"
+import {
+    EngineLogEvent,
+    EngineResultsEvent,
+    EngineRunProgressEvent,
+    EngineTelemetryEvent,
+    Event,
+    EventType,
+    LogLevel
+} from "./events"
 import {getMessage} from "./messages";
 import * as engApi from "@salesforce/code-analyzer-engine-api"
 import {Clock, RealClock} from '@salesforce/code-analyzer-engine-api/utils';
 import {EventEmitter} from "node:events";
 import {CodeAnalyzerConfig, ConfigDescription, EngineOverrides, FIELDS, RuleOverride} from "./config";
-import {
-    EngineProgressAggregator,
-    SimpleUniqueIdGenerator,
-    toAbsolutePath,
-    UniqueIdGenerator
-} from "./utils";
+import {EngineProgressAggregator, SimpleUniqueIdGenerator, toAbsolutePath, UniqueIdGenerator} from "./utils";
 import fs from "node:fs";
 import path from 'node:path';
 
@@ -458,6 +461,16 @@ export class CodeAnalyzer {
                 engineName: engine.getName(),
                 logLevel: event.logLevel as LogLevel,
                 message: event.message
+            });
+        });
+
+        engine.onEvent(engApi.EventType.TelemetryEvent, (event: engApi.TelemetryEvent) => {
+            this.emitEvent<EngineTelemetryEvent>({
+                timestamp: this.clock.now(),
+                engineName: engine.getName(),
+                type: EventType.EngineTelemetryEvent,
+                key: event.key,
+                data: event.data
             });
         });
 

--- a/packages/code-analyzer-core/src/events.ts
+++ b/packages/code-analyzer-core/src/events.ts
@@ -1,3 +1,4 @@
+import * as engApi from "@salesforce/code-analyzer-engine-api"
 import { EngineRunResults } from "./results"
 
 /**
@@ -34,6 +35,8 @@ export type LogEvent = {
     message: string
 }
 
+export type TelemetryData = engApi.TelemetryData;
+
 /**
  * Event emitted to report the progress of an invocation of {@link CodeAnalyzer.selectRules}
  *   These events are received by callbacks provided to the {@link CodeAnalyzer.onEvent} for {@link EventType.RuleSelectionProgressEvent}.
@@ -65,7 +68,7 @@ export type EngineTelemetryEvent = {
     timestamp: Date,
     engineName: string,
     eventName: string,
-    data: {[key: string]: null|boolean|string|number}
+    data: TelemetryData
 }
 
 /**

--- a/packages/code-analyzer-core/src/events.ts
+++ b/packages/code-analyzer-core/src/events.ts
@@ -64,9 +64,8 @@ export type EngineTelemetryEvent = {
     type: EventType.EngineTelemetryEvent,
     timestamp: Date,
     engineName: string,
-    key: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: {[key: string]: any}
+    eventName: string,
+    data: {[key: string]: null|boolean|string|number}
 }
 
 /**

--- a/packages/code-analyzer-core/src/events.ts
+++ b/packages/code-analyzer-core/src/events.ts
@@ -6,6 +6,7 @@ import { EngineRunResults } from "./results"
  */
 export enum EventType {
     LogEvent = "LogEvent",
+    TelemetryEvent = "TelemetryEvent",
     RuleSelectionProgressEvent = "RuleSelectionProgressEvent",
     EngineLogEvent = "EngineLogEvent",
     EngineTelemetryEvent = "EngineTelemetryEvent",
@@ -68,6 +69,7 @@ export type EngineTelemetryEvent = {
     timestamp: Date,
     engineName: string,
     eventName: string,
+    uuid: string,
     data: TelemetryData
 }
 

--- a/packages/code-analyzer-core/src/events.ts
+++ b/packages/code-analyzer-core/src/events.ts
@@ -38,6 +38,14 @@ export type LogEvent = {
 
 export type TelemetryData = engApi.TelemetryData;
 
+export type TelemetryEvent = {
+    type: EventType.TelemetryEvent,
+    timestamp: Date,
+    eventName: string,
+    uuid: string,
+    data: TelemetryData
+}
+
 /**
  * Event emitted to report the progress of an invocation of {@link CodeAnalyzer.selectRules}
  *   These events are received by callbacks provided to the {@link CodeAnalyzer.onEvent} for {@link EventType.RuleSelectionProgressEvent}.
@@ -98,4 +106,4 @@ export type EngineResultsEvent = {
 /**
  * Convenience type corresponding to each of the various events that can be emitted by Code Analyzer
  */
-export type Event = LogEvent | RuleSelectionProgressEvent | EngineLogEvent | EngineTelemetryEvent | EngineRunProgressEvent | EngineResultsEvent;
+export type Event = LogEvent | TelemetryEvent | RuleSelectionProgressEvent | EngineLogEvent | EngineTelemetryEvent | EngineRunProgressEvent | EngineResultsEvent;

--- a/packages/code-analyzer-core/src/events.ts
+++ b/packages/code-analyzer-core/src/events.ts
@@ -7,6 +7,7 @@ export enum EventType {
     LogEvent = "LogEvent",
     RuleSelectionProgressEvent = "RuleSelectionProgressEvent",
     EngineLogEvent = "EngineLogEvent",
+    EngineTelemetryEvent = "EngineTelemetryEvent",
     EngineRunProgressEvent = "EngineRunProgressEvent",
     EngineResultsEvent = "EngineResultsEvent"
 }
@@ -56,6 +57,19 @@ export type EngineLogEvent = {
 }
 
 /**
+ * Event emitted when an engine wants to send a telemetry event.
+ * These events are received by callbacks provided to the {@link CodeAnalyzer.onEvent} method for {@link EventType.EngineTelemetryEvent}.
+ */
+export type EngineTelemetryEvent = {
+    type: EventType.EngineTelemetryEvent,
+    timestamp: Date,
+    engineName: string,
+    key: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: {[key: string]: any}
+}
+
+/**
  * Event emitted when an engine reports on its run progress
  *   These events are received by callbacks provided to the {@link CodeAnalyzer.onEvent} for {@link EventType.EngineRunProgressEvent}.
  */
@@ -80,4 +94,4 @@ export type EngineResultsEvent = {
 /**
  * Convenience type corresponding to each of the various events that can be emitted by Code Analyzer
  */
-export type Event = LogEvent | RuleSelectionProgressEvent | EngineLogEvent | EngineRunProgressEvent | EngineResultsEvent;
+export type Event = LogEvent | RuleSelectionProgressEvent | EngineLogEvent | EngineTelemetryEvent | EngineRunProgressEvent | EngineResultsEvent;

--- a/packages/code-analyzer-core/src/index.ts
+++ b/packages/code-analyzer-core/src/index.ts
@@ -25,7 +25,8 @@ export {
     LogEvent,
     LogLevel,
     RuleSelectionProgressEvent,
-    TelemetryData
+    TelemetryData,
+    TelemetryEvent
 } from "./events"
 
 export {

--- a/packages/code-analyzer-core/src/index.ts
+++ b/packages/code-analyzer-core/src/index.ts
@@ -19,6 +19,7 @@ export {
     EngineLogEvent,
     EngineRunProgressEvent,
     EngineResultsEvent,
+    EngineTelemetryEvent,
     Event,
     EventType,
     LogEvent,

--- a/packages/code-analyzer-core/src/index.ts
+++ b/packages/code-analyzer-core/src/index.ts
@@ -24,7 +24,8 @@ export {
     EventType,
     LogEvent,
     LogLevel,
-    RuleSelectionProgressEvent
+    RuleSelectionProgressEvent,
+    TelemetryData
 } from "./events"
 
 export {

--- a/packages/code-analyzer-core/src/utils.ts
+++ b/packages/code-analyzer-core/src/utils.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
-import crypto from "node:crypto";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
 
 // THIS FILE CONTAINS UTILITIES WHICH ARE USED INTERNALLY ONLY.
 // None of the following exported interfaces and functions should be exported from the index file.

--- a/packages/code-analyzer-core/src/utils.ts
+++ b/packages/code-analyzer-core/src/utils.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import crypto from "node:crypto";
 
 // THIS FILE CONTAINS UTILITIES WHICH ARE USED INTERNALLY ONLY.
 // None of the following exported interfaces and functions should be exported from the index file.
@@ -9,14 +10,20 @@ export function toAbsolutePath(fileOrFolder: string): string {
 }
 
 export interface UniqueIdGenerator {
-    getUniqueId(prefix: string): string;
+    getLocallyUniqueId(prefix: string): string;
+
+    getUniversallyUniqueId(): string;
 }
 
-export class SimpleUniqueIdGenerator implements UniqueIdGenerator {
+export class RuntimeUniqueIdGenerator implements UniqueIdGenerator {
     private counter: number = 0;
 
-    getUniqueId(prefix: string): string {
+    getLocallyUniqueId(prefix: string): string {
         return `${prefix}${++this.counter}`;
+    }
+
+    getUniversallyUniqueId(): string {
+        return crypto.randomUUID();
     }
 }
 

--- a/packages/code-analyzer-core/test/code-analyzer.test.ts
+++ b/packages/code-analyzer-core/test/code-analyzer.test.ts
@@ -711,6 +711,7 @@ describe("Tests for the run method of CodeAnalyzer", () => {
             timestamp: sampleTimestamp,
             engineName: "stubEngine1",
             eventName: 'Engine1RunKey',
+            uuid: "FixedUUID",
             data: {
                 someProperty: 1,
                 someOtherProperty: 'abcde',
@@ -722,6 +723,7 @@ describe("Tests for the run method of CodeAnalyzer", () => {
             timestamp: sampleTimestamp,
             engineName: "stubEngine2",
             eventName: 'Engine2RunKey',
+            uuid: "FixedUUID",
             data: {
                 someProperty: 2,
                 someOtherProperty: 'fghij',

--- a/packages/code-analyzer-core/test/code-analyzer.test.ts
+++ b/packages/code-analyzer-core/test/code-analyzer.test.ts
@@ -710,7 +710,7 @@ describe("Tests for the run method of CodeAnalyzer", () => {
             type: EventType.EngineTelemetryEvent,
             timestamp: sampleTimestamp,
             engineName: "stubEngine1",
-            key: 'Engine1RunKey',
+            eventName: 'Engine1RunKey',
             data: {
                 someProperty: 1,
                 someOtherProperty: 'abcde',
@@ -721,7 +721,7 @@ describe("Tests for the run method of CodeAnalyzer", () => {
             type: EventType.EngineTelemetryEvent,
             timestamp: sampleTimestamp,
             engineName: "stubEngine2",
-            key: 'Engine2RunKey',
+            eventName: 'Engine2RunKey',
             data: {
                 someProperty: 2,
                 someOtherProperty: 'fghij',

--- a/packages/code-analyzer-core/test/code-analyzer.test.ts
+++ b/packages/code-analyzer-core/test/code-analyzer.test.ts
@@ -6,6 +6,7 @@ import {
     EngineLogEvent,
     EngineRunProgressEvent,
     EngineResultsEvent,
+    EngineTelemetryEvent,
     EventType,
     LogEvent,
     LogLevel,
@@ -647,7 +648,7 @@ describe("Tests for the run method of CodeAnalyzer", () => {
         }
     });
 
-    it("When running engines, then engine run results events are emitted correctly when the enginges complete", async () => {
+    it("When running engines, then engine run results events are emitted correctly when the engines complete", async () => {
         const engineResultsEvents: EngineResultsEvent[] = [];
         codeAnalyzer.onEvent(EventType.EngineResultsEvent, (event: EngineResultsEvent) => engineResultsEvents.push(event));
         const runResults: RunResults = await codeAnalyzer.run(selection, sampleRunOptions);
@@ -670,7 +671,7 @@ describe("Tests for the run method of CodeAnalyzer", () => {
         });
     });
 
-    it("When running engines, then engine specific events are wired up and emitted correctly from the engines", async () => {
+    it("When running engines, then engine-specific log events are wired up and emitted correctly from the engines", async () => {
         const engineLogEvents: EngineLogEvent[] = [];
         codeAnalyzer.onEvent(EventType.EngineLogEvent, (event: EngineLogEvent) => engineLogEvents.push(event));
         await codeAnalyzer.run(selection, sampleRunOptions);
@@ -696,6 +697,36 @@ describe("Tests for the run method of CodeAnalyzer", () => {
             engineName: "stubEngine3",
             logLevel: LogLevel.Info,
             message: "someMiscInfoMessageFromStubEngine3"
+        });
+    });
+
+    it("When running engines, then engine-level telemetry events are wired up and emitted correctly from the engines", async () => {
+        const engineTelemetryEvents: EngineTelemetryEvent[] = [];
+        codeAnalyzer.onEvent(EventType.EngineTelemetryEvent, (event: EngineTelemetryEvent) => engineTelemetryEvents.push(event));
+        await codeAnalyzer.run(selection, sampleRunOptions);
+
+        expect(engineTelemetryEvents).toHaveLength(2);
+        expect(engineTelemetryEvents).toContainEqual({
+            type: EventType.EngineTelemetryEvent,
+            timestamp: sampleTimestamp,
+            engineName: "stubEngine1",
+            key: 'Engine1RunKey',
+            data: {
+                someProperty: 1,
+                someOtherProperty: 'abcde',
+                someThirdProperty: true
+            }
+        });
+        expect(engineTelemetryEvents).toContainEqual({
+            type: EventType.EngineTelemetryEvent,
+            timestamp: sampleTimestamp,
+            engineName: "stubEngine2",
+            key: 'Engine2RunKey',
+            data: {
+                someProperty: 2,
+                someOtherProperty: 'fghij',
+                someThirdProperty: false
+            }
         });
     });
 });

--- a/packages/code-analyzer-core/test/rule-selection.test.ts
+++ b/packages/code-analyzer-core/test/rule-selection.test.ts
@@ -2,6 +2,7 @@ import {
     CodeAnalyzer,
     CodeAnalyzerConfig,
     EngineLogEvent,
+    EngineTelemetryEvent,
     EventType,
     LogEvent,
     LogLevel,
@@ -354,7 +355,7 @@ describe('Tests for selecting rules', () => {
         }
     });
 
-    it("When selecting rules, then engine specific log events are wired up and emitted correctly", async () => {
+    it("When selecting rules, then engine-specific log events are wired up and emitted correctly", async () => {
         const engineLogEvents: EngineLogEvent[] = [];
         codeAnalyzer.onEvent(EventType.EngineLogEvent, (event: EngineLogEvent) => engineLogEvents.push(event));
         await codeAnalyzer.selectRules([]);
@@ -380,6 +381,36 @@ describe('Tests for selecting rules', () => {
             engineName: "stubEngine3",
             logLevel: LogLevel.Error,
             message: "someMiscErrorMessageFromStubEngine3"
+        });
+    });
+
+    it("When selecting rules, then engine-level telemetry events are wired up and emitted correctly from the engines", async () => {
+        const engineTelemetryEvents: EngineTelemetryEvent[] = [];
+        codeAnalyzer.onEvent(EventType.EngineTelemetryEvent, (event: EngineTelemetryEvent) => engineTelemetryEvents.push(event));
+        await codeAnalyzer.selectRules([]);
+
+        expect(engineTelemetryEvents).toHaveLength(2);
+        expect(engineTelemetryEvents).toContainEqual({
+            type: EventType.EngineTelemetryEvent,
+            timestamp: sampleTimestamp,
+            engineName: "stubEngine1",
+            key: 'Engine1DescribeKey',
+            data: {
+                someProperty: 4,
+                someOtherProperty: 'klmno',
+                someThirdProperty: true
+            }
+        });
+        expect(engineTelemetryEvents).toContainEqual({
+            type: EventType.EngineTelemetryEvent,
+            timestamp: sampleTimestamp,
+            engineName: "stubEngine2",
+            key: 'Engine2DescribeKey',
+            data: {
+                someProperty: 5,
+                someOtherProperty: 'pqrst',
+                someThirdProperty: false
+            }
         });
     });
 });

--- a/packages/code-analyzer-core/test/rule-selection.test.ts
+++ b/packages/code-analyzer-core/test/rule-selection.test.ts
@@ -395,6 +395,7 @@ describe('Tests for selecting rules', () => {
             timestamp: sampleTimestamp,
             engineName: "stubEngine1",
             eventName: 'Engine1DescribeKey',
+            uuid: "FixedUUID",
             data: {
                 someProperty: 4,
                 someOtherProperty: 'klmno',
@@ -406,6 +407,7 @@ describe('Tests for selecting rules', () => {
             timestamp: sampleTimestamp,
             engineName: "stubEngine2",
             eventName: 'Engine2DescribeKey',
+            uuid: "FixedUUID",
             data: {
                 someProperty: 5,
                 someOtherProperty: 'pqrst',

--- a/packages/code-analyzer-core/test/rule-selection.test.ts
+++ b/packages/code-analyzer-core/test/rule-selection.test.ts
@@ -394,7 +394,7 @@ describe('Tests for selecting rules', () => {
             type: EventType.EngineTelemetryEvent,
             timestamp: sampleTimestamp,
             engineName: "stubEngine1",
-            key: 'Engine1DescribeKey',
+            eventName: 'Engine1DescribeKey',
             data: {
                 someProperty: 4,
                 someOtherProperty: 'klmno',
@@ -405,7 +405,7 @@ describe('Tests for selecting rules', () => {
             type: EventType.EngineTelemetryEvent,
             timestamp: sampleTimestamp,
             engineName: "stubEngine2",
-            key: 'Engine2DescribeKey',
+            eventName: 'Engine2DescribeKey',
             data: {
                 someProperty: 5,
                 someOtherProperty: 'pqrst',

--- a/packages/code-analyzer-core/test/stubs.ts
+++ b/packages/code-analyzer-core/test/stubs.ts
@@ -118,6 +118,11 @@ export class StubEngine1 extends engApi.Engine {
         this.describeRulesCallHistory.push({describeOptions});
         this.emitDescribeRulesProgressEvent(20);
         this.emitLogEvent(engApi.LogLevel.Warn, "someMiscWarnMessageFromStubEngine1");
+        this.emitTelemetryEvent('Engine1DescribeKey', {
+            someProperty: 4,
+            someOtherProperty: 'klmno',
+            someThirdProperty: true
+        });
         this.emitDescribeRulesProgressEvent(80);
         return [
             {
@@ -162,6 +167,11 @@ export class StubEngine1 extends engApi.Engine {
         this.runRulesCallHistory.push({ruleNames, runOptions});
         this.emitRunRulesProgressEvent(0);
         this.emitLogEvent(engApi.LogLevel.Fine, "someMiscFineMessageFromStubEngine1");
+        this.emitTelemetryEvent('Engine1RunKey', {
+            someProperty: 1,
+            someOtherProperty: 'abcde',
+            someThirdProperty: true
+        });
         this.emitRunRulesProgressEvent(50, "someProgressMessage");
         this.emitRunRulesProgressEvent(100);
         return this.resultsToReturn;
@@ -199,6 +209,11 @@ export class StubEngine2 extends engApi.Engine {
         this.describeRulesCallHistory.push({describeOptions});
         this.emitDescribeRulesProgressEvent(30);
         this.emitLogEvent(engApi.LogLevel.Error, "someMiscErrorMessageFromStubEngine2");
+        this.emitTelemetryEvent('Engine2DescribeKey', {
+            someProperty: 5,
+            someOtherProperty: 'pqrst',
+            someThirdProperty: false
+        });
         this.emitDescribeRulesProgressEvent(90);
         return [
             {
@@ -228,6 +243,11 @@ export class StubEngine2 extends engApi.Engine {
     async runRules(ruleNames: string[], runOptions: engApi.RunOptions): Promise<engApi.EngineRunResults> {
         this.runRulesCallHistory.push({ruleNames, runOptions});
         this.emitLogEvent(engApi.LogLevel.Info, "someMiscInfoMessageFromStubEngine2");
+        this.emitTelemetryEvent('Engine2RunKey', {
+            someProperty: 2,
+            someOtherProperty: 'fghij',
+            someThirdProperty: false
+        });
         this.emitRunRulesProgressEvent(5);
         this.emitRunRulesProgressEvent(63);
         return this.resultsToReturn;

--- a/packages/code-analyzer-core/test/test-helpers.ts
+++ b/packages/code-analyzer-core/test/test-helpers.ts
@@ -19,8 +19,11 @@ export function changeWorkingDirectoryToPackageRoot() {
 }
 
 export class FixedUniqueIdGenerator implements UniqueIdGenerator {
-    getUniqueId(_prefix: string): string {
+    getLocallyUniqueId(_prefix: string): string {
         return "FixedId";
     }
 
+    getUniversallyUniqueId(): string {
+        return "FixedUUID";
+    }
 }

--- a/packages/code-analyzer-engine-api/src/engines.ts
+++ b/packages/code-analyzer-engine-api/src/engines.ts
@@ -120,6 +120,7 @@ export abstract class Engine {
      * @param data A flexible payload of relevant data
      * @protected
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected emitTelemetryEvent(key: string, data: {[key: string]: any}): void {
         this.emitEvent({
             type: EventType.TelemetryEvent,

--- a/packages/code-analyzer-engine-api/src/engines.ts
+++ b/packages/code-analyzer-engine-api/src/engines.ts
@@ -115,6 +115,20 @@ export abstract class Engine {
     }
 
     /**
+     * Convenience method that subclasses can use to easily emit an event of type {@link TelemetryEvent}
+     * @param key A (preferably unique) key to associate with this event
+     * @param data A flexible payload of relevant data
+     * @protected
+     */
+    protected emitTelemetryEvent(key: string, data: {[key: string]: any}): void {
+        this.emitEvent({
+            type: EventType.TelemetryEvent,
+            key,
+            data
+        });
+    }
+
+    /**
      * Convenience method that subclasses can use to easily emit an event of type {@link DescribeRulesProgressEvent}
      * @param percentComplete the percent of completion between 0 and 100
      * @protected

--- a/packages/code-analyzer-engine-api/src/engines.ts
+++ b/packages/code-analyzer-engine-api/src/engines.ts
@@ -116,15 +116,14 @@ export abstract class Engine {
 
     /**
      * Convenience method that subclasses can use to easily emit an event of type {@link TelemetryEvent}
-     * @param key A (preferably unique) key to associate with this event
+     * @param eventName A (preferably unique) key to associate with this event
      * @param data A flexible payload of relevant data
      * @protected
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected emitTelemetryEvent(key: string, data: {[key: string]: any}): void {
+    protected emitTelemetryEvent(eventName: string, data: {[key: string]: null|boolean|number|string}): void {
         this.emitEvent({
             type: EventType.TelemetryEvent,
-            key,
+            eventName,
             data
         });
     }

--- a/packages/code-analyzer-engine-api/src/engines.ts
+++ b/packages/code-analyzer-engine-api/src/engines.ts
@@ -1,6 +1,6 @@
 import { RuleDescription } from "./rules";
 import { EngineRunResults } from "./results";
-import {Event, EventType, LogLevel} from "./events";
+import {Event, EventType, LogLevel, TelemetryData} from "./events";
 import { EventEmitter } from "node:events";
 import {Workspace} from "./workspace";
 
@@ -120,7 +120,7 @@ export abstract class Engine {
      * @param data A flexible payload of relevant data
      * @protected
      */
-    protected emitTelemetryEvent(eventName: string, data: {[key: string]: null|boolean|number|string}): void {
+    protected emitTelemetryEvent(eventName: string, data: TelemetryData): void {
         this.emitEvent({
             type: EventType.TelemetryEvent,
             eventName,

--- a/packages/code-analyzer-engine-api/src/events.ts
+++ b/packages/code-analyzer-engine-api/src/events.ts
@@ -29,6 +29,8 @@ export type LogEvent = {
     message: string
 }
 
+export type TelemetryData = Record<string, string|boolean|number>;
+
 /**
  * Event emitted when an engine wants to send telemetry data back up through Core.
  * These events are received by callbacks provided to the {@link Engine.onEvent} method for {@link EventType.TelemetryEvent}.
@@ -36,7 +38,7 @@ export type LogEvent = {
 export type TelemetryEvent = {
     type: EventType.TelemetryEvent,
     eventName: string,
-    data: {[key: string]: null|string|boolean|number}
+    data: TelemetryData
 }
 
 /**

--- a/packages/code-analyzer-engine-api/src/events.ts
+++ b/packages/code-analyzer-engine-api/src/events.ts
@@ -35,9 +35,8 @@ export type LogEvent = {
  */
 export type TelemetryEvent = {
     type: EventType.TelemetryEvent,
-    key: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: {[key: string]: any}
+    eventName: string,
+    data: {[key: string]: null|string|boolean|number}
 }
 
 /**

--- a/packages/code-analyzer-engine-api/src/events.ts
+++ b/packages/code-analyzer-engine-api/src/events.ts
@@ -3,6 +3,7 @@
  */
 export enum EventType {
     LogEvent = "LogEvent",
+    TelemetryEvent = "TelemetryEvent",
     RunRulesProgressEvent = "RunRulesProgressEvent",
     DescribeRulesProgressEvent = "DescribeRulesProgressEvent"
 }
@@ -29,6 +30,17 @@ export type LogEvent = {
 }
 
 /**
+ * Event emitted when an engine wants to send telemetry data back up through Core.
+ * These events are received by callbacks provided to the {@link Engine.onEvent} method for {@link EventType.TelemetryEvent}.
+ */
+export type TelemetryEvent = {
+    type: EventType.TelemetryEvent,
+    key: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: {[key: string]: any}
+}
+
+/**
  * Event that engines should emit during {@link Engine.runRules} to report the progress of the run.
  * These events are received by callbacks provided to the {@link Engine.onEvent} for {@link EventType.RunRulesProgressEvent}.
  */
@@ -50,4 +62,4 @@ export type DescribeRulesProgressEvent = {
 /**
  * Convenience type corresponding to each of the various events that can be emitted by an engine
  */
-export type Event = LogEvent | RunRulesProgressEvent | DescribeRulesProgressEvent;
+export type Event = LogEvent | TelemetryEvent | RunRulesProgressEvent | DescribeRulesProgressEvent;

--- a/packages/code-analyzer-engine-api/src/index.ts
+++ b/packages/code-analyzer-engine-api/src/index.ts
@@ -27,6 +27,7 @@ export {
     LogEvent,
     LogLevel,
     RunRulesProgressEvent,
+    TelemetryData,
     TelemetryEvent
 } from "./events"
 

--- a/packages/code-analyzer-engine-api/src/index.ts
+++ b/packages/code-analyzer-engine-api/src/index.ts
@@ -26,7 +26,8 @@ export {
     EventType,
     LogEvent,
     LogLevel,
-    RunRulesProgressEvent
+    RunRulesProgressEvent,
+    TelemetryEvent
 } from "./events"
 
 export {

--- a/packages/code-analyzer-engine-api/test/api-v1.test.ts
+++ b/packages/code-analyzer-engine-api/test/api-v1.test.ts
@@ -72,7 +72,7 @@ describe('Tests for v1', () => {
         expect(telemetryEvents).toHaveLength(2);
         expect(telemetryEvents[0]).toEqual({
             type: EventType.TelemetryEvent,
-            key: 'DescribeRulesTelemetry',
+            eventName: 'DescribeRulesTelemetry',
             data: {
                 someKey: 1,
                 someOtherKey: true,
@@ -81,7 +81,7 @@ describe('Tests for v1', () => {
         });
         expect(telemetryEvents[1]).toEqual({
             type: EventType.TelemetryEvent,
-            key: 'RunRulesTelemetry',
+            eventName: 'RunRulesTelemetry',
             data: {
                 someKey: 2,
                 someOtherKey: false,

--- a/packages/code-analyzer-engine-api/test/api-v1.test.ts
+++ b/packages/code-analyzer-engine-api/test/api-v1.test.ts
@@ -12,6 +12,7 @@ import {
     RuleDescription,
     RunOptions,
     RunRulesProgressEvent,
+    TelemetryEvent,
     Workspace
 } from "../src";
 import * as os from "node:os";
@@ -40,6 +41,10 @@ describe('Tests for v1', () => {
         dummyEngine.onEvent(EventType.LogEvent, (event: LogEvent): void => {
             logEvents.push(event);
         });
+        const telemetryEvents: TelemetryEvent[] = [];
+        dummyEngine.onEvent(EventType.TelemetryEvent, (event: TelemetryEvent): void => {
+            telemetryEvents.push(event);
+        });
         const describeRulesProgressEvents: DescribeRulesProgressEvent[] = [];
         dummyEngine.onEvent(EventType.DescribeRulesProgressEvent, (event: DescribeRulesProgressEvent): void => {
             describeRulesProgressEvents.push(event);
@@ -64,7 +69,25 @@ describe('Tests for v1', () => {
             logLevel: LogLevel.Fine,
             message: "runRules called"
         });
-
+        expect(telemetryEvents).toHaveLength(2);
+        expect(telemetryEvents[0]).toEqual({
+            type: EventType.TelemetryEvent,
+            key: 'DescribeRulesTelemetry',
+            data: {
+                someKey: 1,
+                someOtherKey: true,
+                someThirdKey: 'beep'
+            }
+        });
+        expect(telemetryEvents[1]).toEqual({
+            type: EventType.TelemetryEvent,
+            key: 'RunRulesTelemetry',
+            data: {
+                someKey: 2,
+                someOtherKey: false,
+                someThirdKey: 'boop'
+            }
+        });
         expect(describeRulesProgressEvents).toHaveLength(2);
         expect(describeRulesProgressEvents).toHaveLength(2);
         expect(describeRulesProgressEvents[0]).toEqual({
@@ -103,6 +126,11 @@ class DummyEngineV1 extends Engine {
     async describeRules(_describeOptions: DescribeOptions): Promise<RuleDescription[]> {
         this.emitDescribeRulesProgressEvent(30);
         this.emitLogEvent(LogLevel.Debug, "describeRules called");
+        this.emitTelemetryEvent('DescribeRulesTelemetry', {
+            someKey: 1,
+            someOtherKey: true,
+            someThirdKey: 'beep'
+        });
         this.emitDescribeRulesProgressEvent(99);
         return [];
     }
@@ -118,6 +146,11 @@ class DummyEngineV1 extends Engine {
     async runRules(_ruleNames: string[], _runOptions: RunOptions): Promise<EngineRunResults> {
         this.emitRunRulesProgressEvent(5.0);
         this.emitLogEvent(LogLevel.Fine, "runRules called");
+        this.emitTelemetryEvent('RunRulesTelemetry', {
+            someKey: 2,
+            someOtherKey: false,
+            someThirdKey: 'boop'
+        });
         this.emitRunRulesProgressEvent(100.0);
         return {
             violations: []


### PR DESCRIPTION
This PR does the following:
- Adds, at the engine-level, a framework for emitting Telemetry Events.
- Adds, at the core-level, an ability to receive engine-level Telemetry Events and re-emit them for reception by CLI, VSCode, or other wrapper layers.