### PR TITLE
CHANGE @W-18396029@ Running tests against only affected packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[package.json]
+indent_size = 2
+
 [*.java]
 indent_style = space
 indent_size = 4

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Support long paths
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -83,4 +86,12 @@ jobs:
         with:
           python-version: 3.12
       - run: npm install
-      - run: npm run all
+      - name: Test changes in affected packages
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          CHANGED_FILES=`git diff --name-only $HEAD_SHA $BASE_SHA`
+          node ./.github/workflows/verify-pr/identify-affected-workspaces.mjs "$CHANGED_FILES"
+          npm run build `cat workspace-args.txt`
+          npm run test `cat workspace-args.txt`
+          npm run lint

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           BASE_SHA=${{ github.event.pull_request.base.sha }}
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          CHANGED_FILES=`git diff --name-only $HEAD_SHA $BASE_SHA`
-          node ./.github/workflows/verify-pr/validate-changed-package-versions.js "$CHANGED_FILES"
+          git diff --name-only $HEAD_SHA $BASE_SHA > changed_files.txt
+          node ./.github/workflows/verify-pr/validate-changed-package-versions.js changed_files.txt
       - name: Validate that packages properly depend on each other
         if: ${{ needs.check_for_postrelease_keyword.outputs.is-postrelease == 'false' }}
         run: |
@@ -90,8 +90,8 @@ jobs:
         run: |
           BASE_SHA=${{ github.event.pull_request.base.sha }}
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          CHANGED_FILES=`git diff --name-only $HEAD_SHA $BASE_SHA`
-          node ./.github/workflows/verify-pr/identify-affected-workspaces.mjs "$CHANGED_FILES"
+          git diff --name-only $HEAD_SHA $BASE_SHA > changed_files.txt
+          node ./.github/workflows/verify-pr/identify-affected-workspaces.mjs changed_files.txt
           npm run build `cat workspace-args.txt`
           npm run test `cat workspace-args.txt`
           npm run lint

--- a/.github/workflows/verify-pr/identify-affected-workspaces.mjs
+++ b/.github/workflows/verify-pr/identify-affected-workspaces.mjs
@@ -53,7 +53,7 @@ function displayList(header, list) {
 }
 
 function readChangedFilesFile(changedFilesFileName) {
-    return fs.readFileSync(path.join(__dirname, '..', '..', '..', changedFilesFileName), 'utf-8').split('\n').map(s => s.trim());
+    return fs.readFileSync(path.join(pathToRoot, changedFilesFileName), 'utf-8').split('\n').map(s => s.trim());
 }
 
 function identifyChangedPackages(changedFiles) {

--- a/.github/workflows/verify-pr/identify-affected-workspaces.mjs
+++ b/.github/workflows/verify-pr/identify-affected-workspaces.mjs
@@ -1,0 +1,104 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import {fileURLToPath} from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const pathToRoot = path.resolve(__dirname, '..', '..', '..');
+
+function main() {
+    const changedFiles = process.argv[2].split('\n');
+    const tmpFilePath = path.join(pathToRoot, 'workspace-args.txt');
+
+    if (changedFiles.length === 0) {
+        console.log('No changed files; no packages need testing');
+        fs.writeFileSync(tmpFilePath, '');
+        console.log(`WROTE EMPTY WORKSPACE ARGS TO ${tmpFilePath}`);
+        process.exit(0);
+    }
+    displayList('THE FOLLOWING FILES WERE CHANGED:', changedFiles);
+
+    const changedPackages = identifyChangedPackages(changedFiles);
+    if (changedPackages.length === 0) {
+        console.log(`No package-level changes. Using empty workspace arg to test all packages.`);
+        fs.writeFileSync(tmpFilePath, '');
+        console.log(`WROTE EMPTY WORKSPACE ARGS TO ${tmpFilePath}`);
+        process.exit(0);
+    }
+    displayList('THE FOLLOWING PACKAGES HAVE CHANGED FILES:', changedPackages);
+
+    const dependentPackages = identifyPackagesWithDependenciesOn(changedPackages);
+    if (dependentPackages.length > 0) {
+        displayList('THE FOLLOWING PACKAGES HAVE DEPENDENCIES ON CHANGED PACKAGES:', dependentPackages);
+    } else {
+        console.log(`NO PACKAGES HAVE DEPENDENCIES ON CHANGED PACKAGES.\n`);
+    }
+
+    const affectedPackages = [...(new Set([...changedPackages, ...dependentPackages]).keys())];
+    displayList('BASED ON THE ABOVE, THE FOLLOWING PACKAGES ARE AFFECTED BY CHANGES, AND WILL REQUIRE TESTING:', affectedPackages);
+
+    const correspondingWorkspaceArgs = affectedPackages.map(name => `--workspace ${name}`);
+    displayList('THOSE PACKAGES CORRESPOND TO THESE WORKSPACE ARGS:', correspondingWorkspaceArgs);
+
+    fs.writeFileSync(tmpFilePath, correspondingWorkspaceArgs.join(' '));
+    console.log(`WROTE WORKSPACE ARGS TO ${tmpFilePath}`);
+}
+
+function displayList(header, list) {
+    console.log(header);
+    for (const listItem of list) {
+        console.log(`* ${listItem}`);
+    }
+    console.log('');
+}
+
+function identifyChangedPackages(changedFiles) {
+    const changedPackages = new Set();
+
+    for (const changedFile of changedFiles) {
+        const changedPackage = convertFileNameToPackageNameIfPossible(changedFile);
+        if (changedPackage) {
+            changedPackages.add(changedPackage);
+        }
+    }
+
+    return [...changedPackages.keys()];
+}
+
+function identifyPackagesWithDependenciesOn(packageNames) {
+    const allPackageJsons = getAllPackageJsons();
+
+    const packagesWithDependencies = [];
+
+    for (const possiblyDependentPackageJson of allPackageJsons) {
+        const possiblyDependentPackageName = possiblyDependentPackageJson.name;
+        for (const possibleDependencyName of packageNames) {
+            const dependencyVersionOrUndefined = possiblyDependentPackageJson.dependencies[possibleDependencyName];
+            if (dependencyVersionOrUndefined) {
+                packagesWithDependencies.push(possiblyDependentPackageName);
+            }
+        }
+    }
+    return packagesWithDependencies;
+}
+
+function convertFileNameToPackageNameIfPossible(changedFile) {
+    const changedFilePathSegments = changedFile.split('/');
+    if (changedFilePathSegments.length < 2 || changedFilePathSegments[0] !== 'packages') {
+        return null;
+    } else {
+        return path.join(changedFilePathSegments[0], changedFilePathSegments[1]);
+    }
+}
+
+function getAllPackageJsons() {
+    const packagesDir = fs.readdirSync(path.join(pathToRoot, 'packages'));
+    return packagesDir.filter(f => fs.statSync(path.join(pathToRoot, 'packages', f)).isDirectory()).map(getPackageJson);
+}
+
+function getPackageJson(packageName) {
+    const packageJsonPath = path.join(pathToRoot, 'packages', packageName, 'package.json');
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+}
+
+main();

--- a/.github/workflows/verify-pr/identify-affected-workspaces.mjs
+++ b/.github/workflows/verify-pr/identify-affected-workspaces.mjs
@@ -7,7 +7,7 @@ const __dirname = path.dirname(__filename);
 const pathToRoot = path.resolve(__dirname, '..', '..', '..');
 
 function main() {
-    const changedFiles = process.argv[2].split('\n');
+    const changedFiles = readChangedFilesFile(process.argv[2]);
     const tmpFilePath = path.join(pathToRoot, 'workspace-args.txt');
 
     if (changedFiles.length === 0) {
@@ -50,6 +50,10 @@ function displayList(header, list) {
         console.log(`* ${listItem}`);
     }
     console.log('');
+}
+
+function readChangedFilesFile(changedFilesFileName) {
+    return fs.readFileSync(path.join(__dirname, '..', '..', '..', changedFilesFileName), 'utf-8').split('\n').map(s => s.trim());
 }
 
 function identifyChangedPackages(changedFiles) {

--- a/.github/workflows/verify-pr/validate-changed-package-versions.js
+++ b/.github/workflows/verify-pr/validate-changed-package-versions.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 
 function main() {
-    const changedFiles = process.argv[2].split('\n');
+    const changedFiles = readChangedFilesFile(process.argv[2]);
     if (changedFiles.length === 0) {
         console.log('No changed files; no verification needed');
         process.exit(0);
@@ -36,6 +36,10 @@ function displayList(header, list) {
         console.log(`* ${listItem}`);
     }
     console.log('');
+}
+
+function readChangedFilesFile(changedFilesFileName) {
+    return fs.readFileSync(path.join(__dirname, '..', '..', '..', changedFilesFileName), 'utf-8').split('\n').map(s => s.trim());
 }
 
 function identifyMeaningfullyChangedPackages(changedFiles) {


### PR DESCRIPTION
This PR makes the following changes:
- The `verify-pr.yml` job can now identify which specific packages are affected by the changes in the PR, and will only run the tests in those packages.

See [this Github Action run from an experimental branch](https://github.com/forcedotcom/code-analyzer-core/actions/runs/14797216614) to see it only running tests for `code-analyzer-regex-engine` and `code-analyzer-flow-engine`, and see the checks for this PR itself for an example of it running on all packages because no specific package was changed.