### PR TITLE
FIX @W-18424011@ Regex engine supports multi-dot file extensions

### DIFF
--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-regex-engine",
   "description": "Plugin package that adds 'regex' as an engine into Salesforce Code Analyzer",
-  "version": "0.21.0",
+  "version": "0.21.1-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-regex-engine/src/config.ts
+++ b/packages/code-analyzer-regex-engine/src/config.ts
@@ -56,7 +56,7 @@ export type RegexRule = {
     include_metadata?: boolean;
 }
 
-export const FILE_EXT_PATTERN: RegExp = /^[.][a-zA-Z0-9]+$/;
+export const FILE_EXT_PATTERN: RegExp = /^([.][a-zA-Z0-9-_]+)+$/;
 export const RULE_NAME_PATTERN: RegExp = /^[A-Za-z@][A-Za-z_0-9@\-/]*$/;
 export const REGEX_STRING_PATTERN: RegExp = /^\/(.*)\/(.*)$/;
 

--- a/packages/code-analyzer-regex-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-regex-engine/test/plugin.test.ts
@@ -31,6 +31,13 @@ const SAMPLE_RAW_CUSTOM_RULE_NO_FILE_EXTS_DEFINITION = {
     tags: ["dummy"]
 }
 
+const SAMPLE_RAW_CUSTOM_RULE_NO_TALKING_ABOUT_FIGHT_CLUB_DEFINITION = {
+    regex: String.raw`/fight club/gi`,
+    description: "The first rule of Fight Club is don't talk about Fight Club",
+    tags: ["PopCulture"],
+    file_extensions: [".cls-meta.xml", ".cls_meta.xml"]
+};
+
 const SAMPLE_DATE: Date = new Date(Date.UTC(2024, 8, 1, 0, 0, 0));
 
 describe('RegexEnginePlugin No Custom Config Tests' , () => {
@@ -110,7 +117,8 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
         const rawConfig: ConfigObject = {
             custom_rules: {
                 NoTodos: SAMPLE_RAW_CUSTOM_RULE_DEFINITION,
-                NoHellos: SAMPLE_RAW_CUSTOM_RULE_NO_FILE_EXTS_DEFINITION
+                NoHellos: SAMPLE_RAW_CUSTOM_RULE_NO_FILE_EXTS_DEFINITION,
+                NoTalkingAboutFightClub: SAMPLE_RAW_CUSTOM_RULE_NO_TALKING_ABOUT_FIGHT_CLUB_DEFINITION
             }
         };
         const valueExtractor: ConfigValueExtractor = new ConfigValueExtractor(rawConfig, 'engines.regex');
@@ -118,6 +126,7 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
         const engine: RegexEngine = await plugin.createEngine('regex', resolvedConfig) as RegexEngine;
         const customNoTodoRuleRegex: RegExp = /TODO:\s/gi;
         const customNoHelloRuleRegex: RegExp = /hello/gi;
+        const customNoTalkingAboutFightClubRegex: RegExp = /fight club/gi;
         const expRegexRules: RegexRules = {
             ...createBaseRegexRules(SAMPLE_DATE),
             NoTodos: {
@@ -134,6 +143,14 @@ describe('RegexEnginePlugin Custom Config Tests', () => {
                 violation_message: getMessage('RuleViolationMessage', customNoHelloRuleRegex.toString(), 'NoHellos', 'Detects hellos in project'),
                 severity: SeverityLevel.Moderate,
                 tags: ['dummy']
+            },
+            NoTalkingAboutFightClub: {
+                regex: customNoTalkingAboutFightClubRegex.toString(),
+                description: SAMPLE_RAW_CUSTOM_RULE_NO_TALKING_ABOUT_FIGHT_CLUB_DEFINITION.description,
+                file_extensions: SAMPLE_RAW_CUSTOM_RULE_NO_TALKING_ABOUT_FIGHT_CLUB_DEFINITION.file_extensions,
+                violation_message: getMessage('RuleViolationMessage', customNoTalkingAboutFightClubRegex.toString(), 'NoTalkingAboutFightClub', 'The first rule of Fight Club is don\'t talk about Fight Club'),
+                severity: SeverityLevel.Moderate,
+                tags: ['PopCulture']
             }
         };
         expect(engine._getRegexRules()).toEqual(expRegexRules);


### PR DESCRIPTION
This PR is a fix for Issue #284 , which concerned the `regex` engine not supporting file extensions with multiple dots in them (e.g., `.cls-meta.xml`).