### PR TITLE
FIX(core): @W-18539707@: Prevent logging rule override if it is the same value as default

### DIFF
--- a/packages/code-analyzer-core/src/code-analyzer.ts
+++ b/packages/code-analyzer-core/src/code-analyzer.ts
@@ -514,12 +514,12 @@ export class CodeAnalyzer {
 
     private updateRuleDescriptionWithOverrides(engineName: string, ruleDescription: engApi.RuleDescription): engApi.RuleDescription {
         const ruleOverride: RuleOverride = this.config.getRuleOverrideFor(engineName, ruleDescription.name);
-        if (ruleOverride.severity) {
+        if (ruleOverride.severity && ruleDescription.severityLevel !== ruleOverride.severity) {
             this.emitLogEvent(LogLevel.Debug, getMessage('RulePropertyOverridden', FIELDS.SEVERITY,
                 ruleDescription.name, engineName, ruleDescription.severityLevel, ruleOverride.severity));
             ruleDescription.severityLevel = ruleOverride.severity as engApi.SeverityLevel;
         }
-        if (ruleOverride.tags) {
+        if (ruleOverride.tags && JSON.stringify(ruleDescription.tags) !== JSON.stringify(ruleOverride.tags)) {
             this.emitLogEvent(LogLevel.Debug, getMessage('RulePropertyOverridden', FIELDS.TAGS,
                 ruleDescription.name, engineName, JSON.stringify(ruleDescription.tags), JSON.stringify(ruleOverride.tags)));
             ruleDescription.tags = ruleOverride.tags;


### PR DESCRIPTION
While looking at this https://github.com/forcedotcom/code-analyzer/issues/1795 I noticed the users log file was flooded with messages like:

[2025-05-09T17:48:57.128Z] Debug Core - The severity value of rule 'ApexNullPointerException' of engine 'sfge' was overridden according to the specified configuration. The old value '3' was replaced with the new value '3'.

But the old value is the same as the new value... so we shouldn't be logging this.

This PR fixes this.