### PR TITLE
FIX @W-19261289@ SFGE treats LimitReached errors as internal errors

### DIFF
--- a/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/rules/Violation.java
+++ b/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/rules/Violation.java
@@ -332,8 +332,7 @@ public abstract class Violation implements Comparable<Violation>, RuleThrowable 
                             message),
                     vertex);
 
-            // TODO: reconsider the name and category. We want users to take followup action.
-            this.ruleName = "LimitReached";
+            this.ruleName = INTERNAL_ERROR_RULENAME;
             this.category = INTERNAL_ERROR_CATEGORY;
             this.description = "";
             this.severity = AbstractRule.SEVERITY.LOW.code;


### PR DESCRIPTION
This is a fix for [Code Analyzer issue 1868](https://github.com/forcedotcom/code-analyzer/issues/1868), in which triggering a LimitReached exception within Graph Engine tanks the entire code analysis because it is returned as a violation for the non-existent `LimitReached` pseudo-rule.
The fix is to change the pseudo-rule name to `InternalExecutionError` so that the pseudo-violation is handled with the same mechanism that handles timeouts and internal errors.
NOTE: Despite my best efforts, I was unable to write code that would trigger a LimitReached error, and was therefore unable to add an automated test. The best I could do was to change [line 97 of `PathExpansionRegistry.java`](https://github.com/forcedotcom/code-analyzer-core/blob/dev/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/graph/ops/expander/PathExpansionRegistry.java#L97) from `if (currentSize >= pathExpansionLimit) {` to `if (currentSize >= 0) {`, thereby forcing a LimitReached exception to fire for every single scan, and manually verify that the exception was logged as an error instead of returned as a violation.