### PR TITLE
CHANGE: @W-19586349@ Fix husky publishing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "showcoverage-java": "npm run showcoverage-java --workspaces --if-present",
     "showcoverage-typescript": "open ./coverage/lcov-report/index.html",
     "showcoverage": "npm run showcoverage-java && npm run showcoverage-typescript",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "devDependencies": {
     "cross-env": "^10.0.0",


### PR DESCRIPTION
This PR: 
- Fixes an issue in our builds where `husky` is causing publishing [failures](https://github.com/forcedotcom/code-analyzer-core/actions/runs/17560934385/job/49877056300#step:5:44). This is because it is a top level dependency, but each monorepo doesn't have (or need) it. The fix I went with is to ensure that a missing husky dependency doesn't prevent publishing, as recommended by their [documentation](https://typicode.github.io/husky/how-to.html#ci-server-and-docker). This looked good locally too.

<img width="718" height="308" alt="Screenshot 2025-09-08 at 3 37 02 PM" src="https://github.com/user-attachments/assets/91c09fe3-b094-49f8-ae4b-8d494a325148" />
