### PR TITLE
FIX: @W-19649732@: Add in @types/semver as prod dependency to fix client build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,10 +1944,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
-      "dev": true,
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -8799,7 +8798,7 @@
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/sarif": "^2.1.7",
-        "@types/semver": "^7.7.0",
+        "@types/semver": "^7.7.1",
         "@types/tmp": "^0.2.6",
         "cross-env": "^10.0.0",
         "eslint": "^9.32.0",
@@ -9320,7 +9319,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/semver": "^7.7.0",
+        "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "cross-env": "^10.0.0",
         "jest": "^30.0.5",
@@ -10247,12 +10246,12 @@
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.29.0-SNAPSHOT",
         "@types/node": "^20.0.0",
+        "@types/semver": "^7.7.1",
         "semver": "^7.7.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@types/jest": "^30.0.0",
-        "@types/semver": "^7.7.0",
         "eslint": "^9.32.0",
         "jest": "^30.0.5",
         "rimraf": "^6.0.1",
@@ -10501,12 +10500,12 @@
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.29.0-SNAPSHOT",
         "@types/node": "^20.0.0",
+        "@types/semver": "^7.7.1",
         "semver": "^7.7.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@types/jest": "^30.0.0",
-        "@types/semver": "^7.7.0",
         "eslint": "^9.32.0",
         "jest": "^30.0.5",
         "rimraf": "^6.0.1",
@@ -11269,7 +11268,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@types/jest": "^30.0.0",
-        "@types/semver": "^7.7.0",
+        "@types/semver": "^7.7.1",
         "eslint": "^9.32.0",
         "jest": "^30.0.5",
         "rimraf": "^6.0.1",

--- a/packages/code-analyzer-core/package.json
+++ b/packages/code-analyzer-core/package.json
@@ -29,7 +29,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/jest": "^30.0.0",
     "@types/sarif": "^2.1.7",
-    "@types/semver": "^7.7.0",
+    "@types/semver": "^7.7.1",
     "@types/tmp": "^0.2.6",
     "cross-env": "^10.0.0",
     "eslint": "^9.32.0",

--- a/packages/code-analyzer-eslint-engine/package.json
+++ b/packages/code-analyzer-eslint-engine/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/semver": "^7.7.0",
+    "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "cross-env": "^10.0.0",
     "jest": "^30.0.5",

--- a/packages/code-analyzer-flow-engine/package.json
+++ b/packages/code-analyzer-flow-engine/package.json
@@ -15,12 +15,12 @@
   "dependencies": {
     "@salesforce/code-analyzer-engine-api": "0.29.0-SNAPSHOT",
     "@types/node": "^20.0.0",
+    "@types/semver": "^7.7.1",
     "semver": "^7.7.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@types/jest": "^30.0.0",
-    "@types/semver": "^7.7.0",
     "eslint": "^9.32.0",
     "jest": "^30.0.5",
     "rimraf": "^6.0.1",

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -15,12 +15,12 @@
   "dependencies": {
     "@salesforce/code-analyzer-engine-api": "0.29.0-SNAPSHOT",
     "@types/node": "^20.0.0",
+    "@types/semver": "^7.7.1",
     "semver": "^7.7.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@types/jest": "^30.0.0",
-    "@types/semver": "^7.7.0",
     "eslint": "^9.32.0",
     "jest": "^30.0.5",
     "rimraf": "^6.0.1",

--- a/packages/code-analyzer-sfge-engine/package.json
+++ b/packages/code-analyzer-sfge-engine/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@types/jest": "^30.0.0",
-    "@types/semver": "^7.7.0",
+    "@types/semver": "^7.7.1",
     "eslint": "^9.32.0",
     "jest": "^30.0.5",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
Background: internal developer found and issue depending on our engines:
<img width="778" height="350" alt="image" src="https://github.com/user-attachments/assets/cde5ec00-f6f5-46ce-8d97-e1eec026485a" />


Note that without this PR, some clients (unless they pull in @types/semver some other way) were unable to build their typescript code fully when that code depends on our PMD/Flow engines. This is because because our `./packages/*/dist/**/*.d.ts` files that that we produce contain import statements to semver but semver doesn't bundle its own types. 

While I was doing this I used `./packages/*/dist/**/*.d.ts` to find all imports in our types files and found the following that needed attention:

"node:worker_threads" from code-analyzer-eslint-engine (already has @types/node in dependencies)
"semver" from code-analyzer-flow-engine (needs @types/semver)
"semver" from code-analyzer-pmd-engine (needs @types/semver)
"retire/lib/types" from code-analyzer-retirejs-engine (already has retirejs engine)
"node-stream-zip" from code-analyzer-retirejs-engine (already has node-stream-zip)

And it showed that only semver wasn't pulling in its own types.