### PR TITLE
FIX @W-19772057@ Fixed oversight in selector code

### DIFF
--- a/packages/code-analyzer-core/package.json
+++ b/packages/code-analyzer-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-core",
   "description": "Core Package for the Salesforce Code Analyzer",
-  "version": "0.37.0",
+  "version": "0.38.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-core/src/selectors.ts
+++ b/packages/code-analyzer-core/src/selectors.ts
@@ -7,10 +7,13 @@ export interface Selector {
 export function toSelector(selectorString: string): Selector {
     // We parse the selector back-to-front, so that the front-most selectors end up at the bottom of the tree we create
     // and therefore get resolved first.
+    console.log(`selector is ${selectorString}`);
     if (selectorString === '') {
+        console.log('a');
         // ERROR CASE: The selector is empty. Possible if you do something like "()" or "a:()".
         throw new Error(getMessage("SelectorCannotBeEmpty"));
     } else if (selectorString.endsWith(')')) {
+        console.log('b');
         // If the selector ends in close-paren, then we need to find the open-paren that matches it.
         const correspondingOpenParen: number = identifyCorrespondingOpenParen(selectorString);
         if (correspondingOpenParen === 0) {
@@ -24,8 +27,10 @@ export function toSelector(selectorString: string): Selector {
             return toComplexSelector(left, right, op);
         }
     } else {
-        const lastComma: number = selectorString.lastIndexOf(',');
-        const lastColon: number = selectorString.lastIndexOf(':');
+        // If there's a close-paren in the string, only look for operators after it.
+        const lastCloseParen: number = Math.max(selectorString.lastIndexOf(')'), 0);
+        const lastComma: number = selectorString.slice(lastCloseParen).lastIndexOf(',');
+        const lastColon: number = selectorString.slice(lastCloseParen).lastIndexOf(':');
 
         // BASE CASE: The selector contains no commas or colons.
         if (lastComma === -1 && lastColon === -1) {
@@ -37,12 +42,12 @@ export function toSelector(selectorString: string): Selector {
         } else if (lastComma !== -1) {
             // Commas resolve before colons, so that "x,a:b" and "a:b,x" both resolve equivalently the combination of
             // "x" and "a:b".
-            const left: string = selectorString.slice(0, lastComma);
-            const right: string = selectorString.slice(lastComma + 1);
+            const left: string = selectorString.slice(0, lastComma + lastCloseParen);
+            const right: string = selectorString.slice(lastComma + lastCloseParen + 1);
             return toComplexSelector(left, right, ',');
         } else {
-            const left: string = selectorString.slice(0, lastColon);
-            const right: string = selectorString.slice(lastColon + 1);
+            const left: string = selectorString.slice(0, lastColon + lastCloseParen);
+            const right: string = selectorString.slice(lastColon + lastCloseParen + 1);
             return toComplexSelector(left, right, ':');
         }
     }

--- a/packages/code-analyzer-core/src/selectors.ts
+++ b/packages/code-analyzer-core/src/selectors.ts
@@ -7,13 +7,10 @@ export interface Selector {
 export function toSelector(selectorString: string): Selector {
     // We parse the selector back-to-front, so that the front-most selectors end up at the bottom of the tree we create
     // and therefore get resolved first.
-    console.log(`selector is ${selectorString}`);
     if (selectorString === '') {
-        console.log('a');
         // ERROR CASE: The selector is empty. Possible if you do something like "()" or "a:()".
         throw new Error(getMessage("SelectorCannotBeEmpty"));
     } else if (selectorString.endsWith(')')) {
-        console.log('b');
         // If the selector ends in close-paren, then we need to find the open-paren that matches it.
         const correspondingOpenParen: number = identifyCorrespondingOpenParen(selectorString);
         if (correspondingOpenParen === 0) {

--- a/packages/code-analyzer-core/test/rule-selection.test.ts
+++ b/packages/code-analyzer-core/test/rule-selection.test.ts
@@ -213,6 +213,44 @@ describe('Tests for selecting rules', () => {
 
     it.each([
         {
+            selector: '(2,3):stubEngine1',
+            engines: ['stubEngine1'],
+            stubEngine1Rules: ['stub1RuleB', 'stub1RuleC', 'stub1RuleE'],
+            stubEngine2Rules: [],
+            stubEngine3Rules: []
+        },
+        {
+            selector: 'stubEngine1:(2,3)',
+            engines: ['stubEngine1'],
+            stubEngine1Rules: ['stub1RuleB', 'stub1RuleC', 'stub1RuleE'],
+            stubEngine2Rules: [],
+            stubEngine3Rules: []
+        },
+        {
+            selector: '(stubEngine1:2),3',
+            engines: ['stubEngine1', 'stubEngine2', 'stubEngine3'],
+            stubEngine1Rules: ['stub1RuleB', 'stub1RuleC', 'stub1RuleE'],
+            stubEngine2Rules: ['stub2RuleA'],
+            stubEngine3Rules: ['stub3RuleA']
+        },
+        {
+            selector: '3,(stubEngine1:2)',
+            engines: ['stubEngine1', 'stubEngine2', 'stubEngine3'],
+            stubEngine1Rules: ['stub1RuleB', 'stub1RuleC', 'stub1RuleE'],
+            stubEngine2Rules: ['stub2RuleA'],
+            stubEngine3Rules: ['stub3RuleA']
+        }
+    ])('Operations within parentheses resolve before operations outside them. Case: $selector', async ({selector, engines, stubEngine1Rules, stubEngine2Rules, stubEngine3Rules}) => {
+        const selection: RuleSelection = await codeAnalyzer.selectRules([selector]);
+
+        expect(selection.getEngineNames()).toEqual(engines);
+        expect(ruleNamesFor(selection, 'stubEngine1')).toEqual(stubEngine1Rules);
+        expect(ruleNamesFor(selection, 'stubEngine2')).toEqual(stubEngine2Rules);
+        expect(ruleNamesFor(selection, 'stubEngine3')).toEqual(stubEngine3Rules);
+    })
+
+    it.each([
+        {
             case: 'colons are used and multiple selectors are provided',
             selectors: ['Recommended:Performance', 'stubEngine2:2', 'stubEngine2:DoesNotExist']
         },


### PR DESCRIPTION
There was a slight oversight in my initial selector code. Previously, it would try to split `(2,3):pmd` into `(2` and `3):pmd` instead of `(2,3)` and `pmd`. This has been addressed.