### PR TITLE
FIX @W-20773280@ Adding changes to exclude react specific extension from lwc analysis

### DIFF
--- a/packages/code-analyzer-eslint-engine/src/base-config.ts
+++ b/packages/code-analyzer-eslint-engine/src/base-config.ts
@@ -105,11 +105,14 @@ export class BaseConfigFactory {
             '@lwc/lwc-platform/valid-offline-wire': 'off'
         }
 
-        // Restrict these configs to just javascript files
+        // Restrict these configs to just javascript files, excluding .jsx and .tsx
+        // since those are React files, not LWC components
+        const lwcExtensions = this.engineConfig.file_extensions.javascript
+            .filter(ext => ext !== '.jsx' && ext !== '.tsx');
         configs = configs.map(config => {
             return {
                 ...config,
-                files: this.engineConfig.file_extensions.javascript.map(ext => `**/*${ext}`)
+                files: lwcExtensions.map(ext => `**/*${ext}`)
             }
         });
 

--- a/packages/code-analyzer-eslint-engine/src/base-config.ts
+++ b/packages/code-analyzer-eslint-engine/src/base-config.ts
@@ -105,10 +105,10 @@ export class BaseConfigFactory {
             '@lwc/lwc-platform/valid-offline-wire': 'off'
         }
 
-        // Restrict these configs to just javascript files, excluding .jsx and .tsx
+        // Restrict these configs to just javascript files, excluding .jsx
         // since those are React files, not LWC components
         const lwcExtensions = this.engineConfig.file_extensions.javascript
-            .filter(ext => ext !== '.jsx' && ext !== '.tsx');
+            .filter(ext => ext !== '.jsx');
         configs = configs.map(config => {
             return {
                 ...config,


### PR DESCRIPTION
Excluding the react specific files LWC config to avoid false positives for it:
```
193   3 (Moderate)   eslint:@lwc/lwc/no-async-operation           utils.js:97:19                   Restricted async operation "setTimeout"
```