### PR TITLE
FIX @W-21101982@ Adding changes to avoid sfge scan when no target files are there

### DIFF
--- a/packages/code-analyzer-sfge-engine/package.json
+++ b/packages/code-analyzer-sfge-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-sfge-engine",
   "description": "Plugin package that adds 'Salesforce Graph Engine' as an engine into Salesforce Code Analyzer",
-  "version": "0.17.0",
+  "version": "0.18.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-sfge-engine/src/engine.ts
+++ b/packages/code-analyzer-sfge-engine/src/engine.ts
@@ -68,6 +68,13 @@ export class SfgeEngine extends Engine {
             return { violations: [] };
         }
 
+        // Get targeted files and return early if empty - prevents SFGE from analyzing all workspace files
+        const targetedFiles: string[] = await runOptions.workspace.getTargetedFiles();
+        if (targetedFiles.length === 0) {
+            this.emitRunRulesProgressEvent(100);
+            return { violations: [] };
+        }
+
         await this.validateWorkspaceCompleteness(runOptions.workspace);
 
         const allRulesInfoList: SfgeRuleInfo[] = await this.getSfgeRuleInfoList(
@@ -95,7 +102,7 @@ export class SfgeEngine extends Engine {
 
         const sfgeResults: SfgeRunResult[] = await this.sfgeWrapper.invokeRunCommand(
             selectedRuleInfoList,
-            await runOptions.workspace.getTargetedFiles(),
+            targetedFiles,
             relevantWorkspaceFiles,
             sfgeRunOptions,
             runOptions.workingFolder,

--- a/packages/code-analyzer-sfge-engine/test/engine.test.ts
+++ b/packages/code-analyzer-sfge-engine/test/engine.test.ts
@@ -133,6 +133,37 @@ describe('SfgeEngine', () => {
             expect(progressEvents.map(e => e.percentComplete)).toEqual([2, 100]);
         });
 
+        it('When targets are empty, no violations are returned and SFGE is not invoked', async () => {
+            // This test verifies that when the workspace contains .cls files but targets are empty
+            // (e.g., after being filtered out by ignores), SFGE returns early without invoking
+            // the Java process. This prevents SFGE from scanning all workspace files when
+            // no targets are provided.
+            const engine: SfgeEngine = new SfgeEngine(DEFAULT_SFGE_ENGINE_CONFIG, fixedClock);
+            // Workspace folder has .cls files, but we pass empty targets
+            const workspace: Workspace = new Workspace(
+                'id',
+                [path.join(TEST_DATA_FOLDER, 'sampleRelevantWorkspace')],
+                [] // Empty targets - simulates all targets being filtered out by ignores
+            );
+            const logEvents: LogEvent[] = [];
+            engine.onEvent(EventType.LogEvent, (e: LogEvent) => logEvents.push(e));
+            const progressEvents: RunRulesProgressEvent[] = [];
+            engine.onEvent(EventType.RunRulesProgressEvent, (e: RunRulesProgressEvent) => progressEvents.push(e));
+            const ruleNames: string[] = ['ApexFlsViolation'];
+
+            // ====== TESTED BEHAVIOR ======
+            const results: EngineRunResults = await engine.runRules(ruleNames, createRunOptions(workspace));
+
+            // ====== ASSERTIONS ======
+            // No violations should be returned
+            expect(results.violations).toHaveLength(0);
+            // SFGE should not be invoked, so no log events about calling Java commands
+            expect(logEvents).toHaveLength(0);
+            // The progress events should skip from the very first one (2%) to the very last one (100%)
+            // This confirms we returned early without running SFGE
+            expect(progressEvents.map(e => e.percentComplete)).toEqual([2, 100]);
+        });
+
         it.each([
             {case: 'a folder with relevant files that do not violate the selected rules', workspacePaths: [path.join(TEST_DATA_FOLDER, 'sampleRelevantWorkspace')]},
             {


### PR DESCRIPTION
SFGE was scanning all the Apex files in the workspace when the same file was present in the target and the same file was present in the ignore as well. This can impact the performance especially for the extension when we try to scan the file which is matching the ignored pattern. 