### PR TITLE
CHANGE @W-20621708@ - Updated Node dependencies for engine-api, flow, regex, retirejs, and …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9705,17 +9705,17 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^20.0.0",
-        "minimatch": "^9.0.0"
+        "minimatch": "^10.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -9745,6 +9745,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "packages/code-analyzer-engine-api/node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/code-analyzer-engine-api/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/code-analyzer-engine-api/node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/code-analyzer-engine-api/node_modules/@eslint/js": {
       "version": "9.39.2",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
@@ -9758,14 +9789,25 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "packages/code-analyzer-engine-api/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "packages/code-analyzer-engine-api/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "packages/code-analyzer-engine-api/node_modules/eslint": {
@@ -9858,6 +9900,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "packages/code-analyzer-engine-api/node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/code-analyzer-engine-api/node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/code-analyzer-engine-api/node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/code-analyzer-engine-api/node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -9937,15 +10010,18 @@
       }
     },
     "packages/code-analyzer-engine-api/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/code-analyzer-eslint-engine": {
@@ -10905,17 +10981,17 @@
         "@salesforce/code-analyzer-engine-api": "0.35.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "@types/semver": "^7.7.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11418,10 +11494,10 @@
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11684,10 +11760,10 @@
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11941,7 +12017,7 @@
       "dependencies": {
         "@salesforce/code-analyzer-engine-api": "0.35.0-SNAPSHOT",
         "@types/node": "^20.0.0",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -11949,10 +12025,10 @@
         "@types/semver": "^7.7.1",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/code-analyzer-engine-api/package.json
+++ b/packages/code-analyzer-engine-api/package.json
@@ -17,17 +17,17 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@types/node": "^20.0.0",
-    "minimatch": "^9.0.0"
+    "minimatch": "^10.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/jest": "^30.0.0",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-flow-engine/package.json
+++ b/packages/code-analyzer-flow-engine/package.json
@@ -16,17 +16,17 @@
     "@salesforce/code-analyzer-engine-api": "0.35.0-SNAPSHOT",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.7.1",
-    "semver": "^7.7.3"
+    "semver": "^7.7.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/jest": "^30.0.0",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-regex-engine/package.json
+++ b/packages/code-analyzer-regex-engine/package.json
@@ -23,10 +23,10 @@
     "@types/jest": "^30.0.0",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-retirejs-engine/package.json
+++ b/packages/code-analyzer-retirejs-engine/package.json
@@ -24,10 +24,10 @@
     "@types/jest": "^30.0.0",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/code-analyzer-sfge-engine/package.json
+++ b/packages/code-analyzer-sfge-engine/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@salesforce/code-analyzer-engine-api": "0.35.0-SNAPSHOT",
     "@types/node": "^20.0.0",
-    "semver": "^7.7.3"
+    "semver": "^7.7.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
@@ -23,10 +23,10 @@
     "@types/semver": "^7.7.1",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
…sfge engines

## Changes

### code-analyzer-engine-api
Updated packages with ^ symbol:
- minimatch: ^9.0.0 → ^10.2.1
- rimraf: ^6.1.2 → ^6.1.3
- typescript-eslint: ^8.53.0 → ^8.56.0

Constraints followed:
- ✅ Kept @types/node at ^20.0.0 (Node 20 is minimum customer version)
- ✅ Kept eslint at ^9.39.2 (v10 has breaking changes)
- ✅ Kept @eslint/js at ^9.39.2 (v10 has breaking changes)

Tests: ✅ 189 passed

### code-analyzer-flow-engine
Updated packages with ^ symbol:
- semver: ^7.7.3 → ^7.7.4
- rimraf: ^6.1.2 → ^6.1.3
- typescript-eslint: ^8.53.0 → ^8.56.0

Constraints followed:
- ✅ Kept @types/node at ^20.0.0
- ✅ Kept eslint at ^9.39.2
- ✅ Kept @eslint/js at ^9.39.2

Tests: ✅ 59 passed

### code-analyzer-regex-engine
Updated packages with ^ symbol:
- rimraf: ^6.1.2 → ^6.1.3
- typescript-eslint: ^8.53.0 → ^8.56.0

Constraints followed:
- ✅ Kept @types/node at ^20.0.0
- ✅ Kept eslint at ^9.39.2
- ✅ Kept @eslint/js at ^9.39.2
- ✅ Kept isbinaryfile at ^5.0.0 (v6 may have breaking changes)
- ✅ Kept p-limit at ^3.1.0 (v4+ is ESM-only, breaks CommonJS)

Tests: ✅ 65 passed

### code-analyzer-retirejs-engine
Updated packages with ^ symbol:
- rimraf: ^6.1.2 → ^6.1.3
- typescript-eslint: ^8.53.0 → ^8.56.0

Constraints followed:
- ✅ Kept @types/node at ^20.0.0
- ✅ Kept eslint at ^9.39.2
- ✅ Kept @eslint/js at ^9.39.2
- ✅ Kept isbinaryfile at ^5.0.0

Tests: ✅ 31 passed (8 skipped)

### code-analyzer-sfge-engine
Updated packages with ^ symbol:
- semver: ^7.7.3 → ^7.7.4
- rimraf: ^6.1.2 → ^6.1.3
- typescript-eslint: ^8.53.0 → ^8.56.0

Constraints followed:
- ✅ Kept @types/node at ^20.0.0
- ✅ Kept eslint at ^9.39.2
- ✅ Kept @eslint/js at ^9.39.2

Tests: ✅ 96 passed

## Testing Summary
- ✅ All builds successful
- ✅ Total tests: 440 passed across all 5 engines
- ✅ No breaking changes introduced
- ✅ All version constraints respected