### PR TITLE
CHANGE @W-20621708@ - Updated Node dependencies for code-analyzer-core package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9449,7 +9449,7 @@
         "@types/node": "^20.0.0",
         "csv-stringify": "^6.6.0",
         "js-yaml": "^4.1.1",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "xmlbuilder": "^15.1.1"
       },
       "devDependencies": {
@@ -9461,10 +9461,10 @@
         "cross-env": "^10.1.0",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/code-analyzer-core/package.json
+++ b/packages/code-analyzer-core/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20.0.0",
     "csv-stringify": "^6.6.0",
     "js-yaml": "^4.1.1",
-    "semver": "^7.7.3",
+    "semver": "^7.7.4",
     "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {
@@ -32,10 +32,10 @@
     "cross-env": "^10.1.0",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Changes

### code-analyzer-core (0.43.0-SNAPSHOT)
Updated packages with ^ symbol:
- semver: ^7.7.3 → ^7.7.4
- rimraf: ^6.1.2 → ^6.1.3
- typescript-eslint: ^8.53.0 → ^8.56.0

**Constraints followed:**
- Kept @types/node at ^20.0.0 (Node 20 is minimum customer version)
- Kept eslint at ^9.39.2 (v10 has breaking changes)
- Kept @eslint/js at ^9.39.2 (v10 has breaking changes)
- No version bump (already using 0.43.0-SNAPSHOT suffix)

## Testing
- Build successful
- Tests: 282 passed
- No breaking changes introduced

<img width="434" height="81" alt="image" src="https://github.com/user-attachments/assets/0fa75ced-f0ab-4c18-a3f3-9a8cc3e53421" />


## Context
This update was done after merging all engine dependency updates:
- PMD engine upgrade (7.20.0 → 7.21.0)
- ESLint engines upgrade
- All other engines (engine-api, flow, regex, retirejs, sfge)

All engine references remain compatible with their updated versions.