### PR TITLE
NEW @W-21365643@ - Optimize SFGE Path Expansion Rule Performance

### DIFF
--- a/packages/code-analyzer-sfge-engine/package.json
+++ b/packages/code-analyzer-sfge-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-sfge-engine",
   "description": "Plugin package that adds 'Salesforce Graph Engine' as an engine into Salesforce Code Analyzer",
-  "version": "0.18.0-SNAPSHOT",
+  "version": "0.19.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/config/EnvUtil.java
+++ b/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/config/EnvUtil.java
@@ -25,7 +25,7 @@ public final class EnvUtil {
 
     @VisibleForTesting
     static final long DEFAULT_RULE_THREAD_TIMEOUT =
-            TimeUnit.MILLISECONDS.convert(3, TimeUnit.MINUTES);
+            TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS);
 
     @VisibleForTesting static final boolean DEFAULT_RULE_DISABLE_WARNING_VIOLATION = false;
     @VisibleForTesting static final boolean DEFAULT_LOG_WARNINGS_ON_VERBOSE = false;

--- a/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/config/EnvUtil.java
+++ b/packages/code-analyzer-sfge-engine/sfge/src/main/java/com/salesforce/config/EnvUtil.java
@@ -21,11 +21,11 @@ public final class EnvUtil {
     // TODO: These should move to SfgeConfigImpl and this class should return Optionals
     @VisibleForTesting
     static final int DEFAULT_RULE_THREAD_COUNT =
-            Math.min(Runtime.getRuntime().availableProcessors(), 4);
+            Math.min(Runtime.getRuntime().availableProcessors(), 8);
 
     @VisibleForTesting
     static final long DEFAULT_RULE_THREAD_TIMEOUT =
-            TimeUnit.MILLISECONDS.convert(15, TimeUnit.MINUTES);
+            TimeUnit.MILLISECONDS.convert(3, TimeUnit.MINUTES);
 
     @VisibleForTesting static final boolean DEFAULT_RULE_DISABLE_WARNING_VIOLATION = false;
     @VisibleForTesting static final boolean DEFAULT_LOG_WARNINGS_ON_VERBOSE = false;

--- a/packages/code-analyzer-sfge-engine/src/config.ts
+++ b/packages/code-analyzer-sfge-engine/src/config.ts
@@ -28,7 +28,7 @@ export const DEFAULT_SFGE_ENGINE_CONFIG: SfgeEngineConfig = {
     disable_limit_reached_violations: false,
     java_max_heap_size: undefined,
     java_thread_count: 8,
-    java_thread_timeout: 180000
+    java_thread_timeout: 30000
 };
 
 export const SFGE_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {

--- a/packages/code-analyzer-sfge-engine/src/config.ts
+++ b/packages/code-analyzer-sfge-engine/src/config.ts
@@ -27,8 +27,8 @@ export const DEFAULT_SFGE_ENGINE_CONFIG: SfgeEngineConfig = {
     java_command: DEFAULT_JAVA_COMMAND,
     disable_limit_reached_violations: false,
     java_max_heap_size: undefined,
-    java_thread_count: 4,
-    java_thread_timeout: 900000
+    java_thread_count: 8,
+    java_thread_timeout: 180000
 };
 
 export const SFGE_ENGINE_CONFIG_DESCRIPTION: ConfigDescription = {

--- a/packages/code-analyzer-sfge-engine/src/engine.ts
+++ b/packages/code-analyzer-sfge-engine/src/engine.ts
@@ -19,6 +19,10 @@ import {RuntimeSfgeWrapper, SfgeRuleInfo, SfgeRunOptions, SfgeRunResult} from ".
 import {SfgeEngineConfig} from "./config";
 
 const SFGE_RELEVANT_FILE_EXTENSIONS = ['.cls', '.trigger', '-meta.xml', '.page', '.component'];
+// SFGE can only create entry points from Apex source files — filtering targets
+// to these extensions prevents SFGE from receiving non-Apex files as targets,
+// which would cause useless union() branches during static rule graph traversal.
+const SFGE_TARGET_FILE_EXTENSIONS = ['.cls', '.trigger'];
 const DEV_PREVIEW_TAG: string = 'DevPreview';
 
 export class SfgeEngine extends Engine {
@@ -68,8 +72,10 @@ export class SfgeEngine extends Engine {
             return { violations: [] };
         }
 
-        // Get targeted files and return early if empty - prevents SFGE from analyzing all workspace files
-        const targetedFiles: string[] = await runOptions.workspace.getTargetedFiles();
+        // Get targeted files and filter to Apex source only (.cls and .trigger).
+        // SFGE only creates entry points from Apex files; passing non-Apex targets
+        // causes useless union() branches during graph traversal with no benefit.
+        const targetedFiles: string[] = (await runOptions.workspace.getTargetedFiles()).filter(isApexSourceFile);
         if (targetedFiles.length === 0) {
             this.emitRunRulesProgressEvent(100);
             return { violations: [] };
@@ -195,6 +201,10 @@ function getCacheKey(workspace?: Workspace): string {
 
 function isFileRelevantToSfge(fileName: string): boolean {
     return SFGE_RELEVANT_FILE_EXTENSIONS.some(extension => fileName.toLowerCase().endsWith(extension));
+}
+
+function isApexSourceFile(fileName: string): boolean {
+    return SFGE_TARGET_FILE_EXTENSIONS.some(extension => fileName.toLowerCase().endsWith(extension));
 }
 
 function toRuleDescription(sfgeRuleInfo: SfgeRuleInfo): RuleDescription {

--- a/packages/code-analyzer-sfge-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-sfge-engine/test/plugin.test.ts
@@ -61,7 +61,7 @@ describe('SfgeEnginePlugin', () => {
                 disable_limit_reached_violations: false,
                 java_max_heap_size: undefined,
                 java_thread_count: 8,
-                java_thread_timeout: 180000
+                java_thread_timeout: 30000
             });
         });
 

--- a/packages/code-analyzer-sfge-engine/test/plugin.test.ts
+++ b/packages/code-analyzer-sfge-engine/test/plugin.test.ts
@@ -60,8 +60,8 @@ describe('SfgeEnginePlugin', () => {
                 java_command: resolvedConfig.java_command, // We just checked the Java Command above.
                 disable_limit_reached_violations: false,
                 java_max_heap_size: undefined,
-                java_thread_count: 4,
-                java_thread_timeout: 900000
+                java_thread_count: 8,
+                java_thread_timeout: 180000
             });
         });
 


### PR DESCRIPTION
…mance

- Increase default java_thread_count from 4 to 8 for faster parallel execution
- Reduce default java_thread_timeout from 15 min (900000ms) to 30 sec (30000ms)
- Update Java EnvUtil.java defaults to match TypeScript config.ts defaults
- Both values remain configurable via CLI --sfge-thread-count and --sfge-thread-timeout flags or via engines.sfge section in code-analyzer.yaml