### PR TITLE
CHANGE @W-21363989@ - Upgrade PMD from 7.21.0 to 7.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9428,10 +9428,10 @@
     },
     "packages/code-analyzer-core": {
       "name": "@salesforce/code-analyzer-core",
-      "version": "0.44.0",
+      "version": "0.45.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "csv-stringify": "^6.6.0",
         "isbinaryfile": "^5.0.4",
@@ -9688,7 +9688,7 @@
     },
     "packages/code-analyzer-engine-api": {
       "name": "@salesforce/code-analyzer-engine-api",
-      "version": "0.35.0",
+      "version": "0.36.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^20.0.0",
@@ -10021,8 +10021,8 @@
         "@lwc/eslint-plugin-lwc": "^3.3.0",
         "@lwc/eslint-plugin-lwc-platform": "^6.3.0",
         "@salesforce-ux/eslint-plugin-slds": "^1.1.0",
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
-        "@salesforce/code-analyzer-eslint8-engine": "0.12.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
+        "@salesforce/code-analyzer-eslint8-engine": "0.13.0-SNAPSHOT",
         "@salesforce/eslint-config-lwc": "^4.1.2",
         "@salesforce/eslint-plugin-lightning": "^2.0.0",
         "@types/node": "^20.0.0",
@@ -10562,7 +10562,7 @@
     },
     "packages/code-analyzer-eslint8-engine": {
       "name": "@salesforce/code-analyzer-eslint8-engine",
-      "version": "0.12.0",
+      "version": "0.13.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "7.27.4",
@@ -10570,7 +10570,7 @@
         "@eslint/js": "8.57.1",
         "@lwc/eslint-plugin-lwc": "2.2.0",
         "@lwc/eslint-plugin-lwc-platform": "5.2.0",
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@salesforce/eslint-config-lwc": "3.7.2",
         "@salesforce/eslint-plugin-lightning": "1.0.1",
         "@types/node": "^20.0.0",
@@ -10962,10 +10962,10 @@
     },
     "packages/code-analyzer-flow-engine": {
       "name": "@salesforce/code-analyzer-flow-engine",
-      "version": "0.34.0",
+      "version": "0.35.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "@types/semver": "^7.7.1",
         "semver": "^7.7.4"
@@ -11215,10 +11215,10 @@
     },
     "packages/code-analyzer-pmd-engine": {
       "name": "@salesforce/code-analyzer-pmd-engine",
-      "version": "0.37.0",
+      "version": "0.39.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "@types/semver": "^7.7.1",
         "semver": "^7.7.4"
@@ -11468,10 +11468,10 @@
     },
     "packages/code-analyzer-regex-engine": {
       "name": "@salesforce/code-analyzer-regex-engine",
-      "version": "0.33.1-SNAPSHOT",
+      "version": "0.34.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "isbinaryfile": "^5.0.0",
         "p-limit": "^3.1.0"
@@ -11721,10 +11721,10 @@
     },
     "packages/code-analyzer-retirejs-engine": {
       "name": "@salesforce/code-analyzer-retirejs-engine",
-      "version": "0.32.0",
+      "version": "0.33.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "isbinaryfile": "^5.0.0",
         "node-stream-zip": "^1.15.0",
@@ -11978,7 +11978,7 @@
       "version": "0.19.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0",
         "semver": "^7.7.4"
       },
@@ -12231,7 +12231,7 @@
       "version": "0.1.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/code-analyzer-engine-api": "0.35.0",
+        "@salesforce/code-analyzer-engine-api": "0.36.0-SNAPSHOT",
         "@types/node": "^20.0.0"
       },
       "devDependencies": {

--- a/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
+++ b/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
@@ -8,7 +8,7 @@
 [versions]
 hamcrest = "3.0"
 junit-jupiter = "5.14.3"
-pmd = "7.21.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
+pmd = "7.22.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
 
 # For the following: Keep in sync with whatever pmd-core pulls in. Basically, we don't want duplicates in our java-lib folder.
 # To see pmd-core's dependencies, go to https://mvnrepository.com/artifact/net.sourceforge.pmd/pmd-core

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-pmd-engine",
   "description": "Plugin package that adds 'pmd' and 'cpd' as engines into Salesforce Code Analyzer",
-  "version": "0.38.0-SNAPSHOT",
+  "version": "0.39.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-pmd-engine/src/constants.ts
+++ b/packages/code-analyzer-pmd-engine/src/constants.ts
@@ -1,5 +1,5 @@
 // !!! IMPORTANT !!! KEEP THIS IN SYNC WITH gradle/libs.versions.toml
-export const PMD_VERSION: string = '7.21.0';
+export const PMD_VERSION: string = '7.22.0';
 
 export const PMD_ENGINE_NAME: string = "pmd";
 export const CPD_ENGINE_NAME: string = "cpd";


### PR DESCRIPTION
@W-21363989 - 


- Updated gradle/libs.versions.toml
- Updated src/constants.ts PMD_VERSION
- Bumped package version to 0.39.0-SNAPSHOT
- All 127 tests passing with 98.84% coverage

PMD 7.22.0 Changes:
- New Java rule: UnnecessaryInterfaceDeclaration
- CloseResource rule enhanced with allowedResourceMethodPatterns
- Security fixes for XSS vulnerabilities in HTML reports
- Visualforce DataType enum deprecated