### PR TITLE
CHANGE @W-22270236@ - Upgrade PMD from 7.23.0 to 7.24.0 

### DIFF
--- a/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
+++ b/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
@@ -8,7 +8,7 @@
 [versions]
 hamcrest = "3.0"
 junit-jupiter = "5.14.3"
-pmd = "7.23.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
+pmd = "7.24.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
 
 # For the following: Keep in sync with whatever pmd-core pulls in. Basically, we don't want duplicates in our java-lib folder.
 # To see pmd-core's dependencies, go to https://mvnrepository.com/artifact/net.sourceforge.pmd/pmd-core

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-pmd-engine",
   "description": "Plugin package that adds 'pmd' and 'cpd' as engines into Salesforce Code Analyzer",
-  "version": "0.40.0",
+  "version": "0.41.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-pmd-engine/src/constants.ts
+++ b/packages/code-analyzer-pmd-engine/src/constants.ts
@@ -1,5 +1,5 @@
 // !!! IMPORTANT !!! KEEP THIS IN SYNC WITH gradle/libs.versions.toml
-export const PMD_VERSION: string = '7.23.0';
+export const PMD_VERSION: string = '7.24.0';
 
 export const PMD_ENGINE_NAME: string = "pmd";
 export const CPD_ENGINE_NAME: string = "cpd";

--- a/packages/code-analyzer-pmd-engine/src/pmd-rule-mappings.ts
+++ b/packages/code-analyzer-pmd-engine/src/pmd-rule-mappings.ts
@@ -116,6 +116,10 @@ export const RULE_MAPPINGS: Record<string, {severity: SeverityLevel, tags: strin
         severity: SeverityLevel.Moderate,
         tags: [COMMON_TAGS.RECOMMENDED, COMMON_TAGS.CATEGORIES.ERROR_PRONE,    COMMON_TAGS.LANGUAGES.APEX]
     },
+    "AvoidInterfaceAsMapKey": {
+        severity: SeverityLevel.Moderate,
+        tags: [COMMON_TAGS.RECOMMENDED, COMMON_TAGS.CATEGORIES.ERROR_PRONE,    COMMON_TAGS.LANGUAGES.APEX]
+    },
     "AvoidLogicInTrigger": {
         severity: SeverityLevel.Moderate,
         tags: [COMMON_TAGS.RECOMMENDED, COMMON_TAGS.CATEGORIES.BEST_PRACTICES, COMMON_TAGS.LANGUAGES.APEX]

--- a/packages/code-analyzer-pmd-engine/test/test-data/pmdGoldfiles/rules_apexOnly.goldfile.json
+++ b/packages/code-analyzer-pmd-engine/test/test-data/pmdGoldfiles/rules_apexOnly.goldfile.json
@@ -428,6 +428,19 @@
     ]
   },
   {
+    "name": "AvoidInterfaceAsMapKey",
+    "severityLevel": 3,
+    "tags": [
+      "Recommended",
+      "ErrorProne",
+      "Apex"
+    ],
+    "description": "In Apex, when a `Map` uses an interface as key and an abstract class implements that interface and defines `equals`/`hashCode`, methods like `containsKey` do not dispatch to the correct implementation. This results in potentially duplicated map entries or not being able to get entries by key. This rule reports `Map` declarations (fields, variables, parameters) whose key type is an... Learn more: https://docs.pmd-code.org/pmd-doc-{{PMD_VERSION}}/pmd_rules_apex_errorprone.html#avoidinterfaceasmapkey",
+    "resourceUrls": [
+      "https://docs.pmd-code.org/pmd-doc-{{PMD_VERSION}}/pmd_rules_apex_errorprone.html#avoidinterfaceasmapkey"
+    ]
+  },
+  {
     "name": "AvoidInvalidCrudContentDistribution",
     "severityLevel": 3,
     "tags": [
@@ -1041,7 +1054,7 @@
       "Design",
       "Apex"
     ],
-    "description": "Avoid having unused methods since they make understanding and maintaining code harder. This rule finds not only unused private methods, but public methods as well, as long as the class itself is not entirely unused. A class is considered used, if it contains at least one other method/variable declaration that is used, as shown in the test project file Foo.cls. ApexLink is used to make this possible... Learn more: https://docs.pmd-code.org/pmd-doc-{{PMD_VERSION}}/pmd_rules_apex_design.html#unusedmethod",
+    "description": "Avoid having unused methods since they make understanding and maintaining code harder. This rule finds not only unused private methods, but public methods as well, as long as the class itself is not entirely unused. A class is considered used, if it contains at least one other method/variable declaration that is used, as shown in the test project file Foo.cls. Apex Language Server is used to make this... Learn more: https://docs.pmd-code.org/pmd-doc-{{PMD_VERSION}}/pmd_rules_apex_design.html#unusedmethod",
     "resourceUrls": [
       "https://docs.pmd-code.org/pmd-doc-{{PMD_VERSION}}/pmd_rules_apex_design.html#unusedmethod"
     ]


### PR DESCRIPTION
Updates PMD engine to version 7.24.0 with the following changes:

## PMD Version Update
- Updated PMD from 7.23.0 to 7.24.0
- Bumped package version to 0.41.0-SNAPSHOT

## New Rules Added
- **AvoidInterfaceAsMapKey**: Detects when a Map uses an interface as key, which can cause issues with equals/hashCode dispatch in Apex
  - Severity: Moderate
  - Tags: Recommended, ErrorProne, Apex

## Rule Description Updates
- **UnusedMethod**: Updated description text from "ApexLink" to "Apex Language Server" (terminology update by PMD)

## Files Changed
- gradle/libs.versions.toml - PMD version
- src/constants.ts - PMD version constant
- package.json - Package version bump
- src/pmd-rule-mappings.ts - Added AvoidInterfaceAsMapKey rule
- test/test-data/pmdGoldfiles/rules_apexOnly.goldfile.json - Updated test expectations


## PMD Comparison Results: 7.23.0 → 7.24.0
-Scanned 435 repositories with 486,214 total violation comparisons
-Result: 15 mismatches (0.003% difference) 
-Total new violations detected: +15 security issues that were previously missed
-Violations removed: 0 (no regressions)
-All mismatches are bug fixes where PMD 7.24.0 correctly detects security vulnerabilities that 7.23.0 was missing (false negatives).

## References
- PMD 7.24.0 Release Notes: https://docs.pmd-code.org/latest/pmd_release_notes_pmd_7.html#24-may-2024---7240