### PR TITLE
CHANGE @W-22462036@ fix: [BUG][code-analyzer] SSR checks done for LWC which are non lightning__ServerRenderable or lightning__ServerRenderableWithHydration (#2049)

### DIFF
--- a/packages/code-analyzer-eslint-engine/package.json
+++ b/packages/code-analyzer-eslint-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-eslint-engine",
   "description": "Plugin package that adds 'eslint' as an engine into Salesforce Code Analyzer",
-  "version": "0.43.0",
+  "version": "0.43.1-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-eslint-engine/src/base-config.ts
+++ b/packages/code-analyzer-eslint-engine/src/base-config.ts
@@ -140,6 +140,11 @@ export class BaseConfigFactory {
             }
         };
 
+        // Add SSR processor to enable SSR-only linting for SSR-enabled components
+        // The processor checks -meta.xml files for SSR capabilities and only creates virtual .ssrjs files
+        // for components with lightning__ServerRenderable or lightning__ServerRenderableWithHydration
+        configs[0].processor = '@lwc/lwc/ssr';
+
         // File patterns for different config types
         const allJsExtensions = this.engineConfig.file_extensions.javascript;
         const lwcExtensions = allJsExtensions.filter(ext => ext !== '.jsx');
@@ -194,6 +199,7 @@ export class BaseConfigFactory {
         // we can work with the original index [4] instead of [3] to avoid confusion.
         configs.splice(1, 1);
 
+        // The SSR processor is already configured in configs[0] by createJavascriptPlusLwcConfigArray()
         return configs;
     }
 

--- a/packages/code-analyzer-eslint-engine/test/ssr-processor.test.ts
+++ b/packages/code-analyzer-eslint-engine/test/ssr-processor.test.ts
@@ -1,0 +1,88 @@
+import {
+    ConfigObject,
+    Engine,
+    EngineRunResults,
+    RunOptions,
+    Workspace
+} from "@salesforce/code-analyzer-engine-api";
+import * as path from "node:path";
+import {ESLintEnginePlugin} from "../src";
+import {ESLintEngine} from "../src/engine";
+import {createRunOptions} from "./test-helpers";
+
+jest.setTimeout(60_000);
+
+const testDataFolder: string = path.join(__dirname, 'test-data');
+const workspaceWithNonSSRLwc: string = path.join(testDataFolder, 'workspaceWithNonSSRLwc');
+
+async function createEngineFromPlugin(configObject: ConfigObject): Promise<Engine> {
+    const plugin: ESLintEnginePlugin = new ESLintEnginePlugin();
+    const engine: ESLintEngine = await plugin.createEngine('eslint', configObject);
+    engine._runESLintWorkerTask._runInCurrentThreadInsteadofNewThread = true;
+    return engine;
+}
+
+describe('SSR Processor Configuration', () => {
+    describe('Issue 2049: SSR rules should only apply to SSR-enabled components', () => {
+        it('should not report SSR rule violations on non-SSR LWC components', async () => {
+            // Setup: Default config with LWC enabled
+            const defaultConfig: ConfigObject = {
+                file_extensions: {
+                    javascript: ['.js'],
+                    typescript: ['.ts'],
+                    html: ['.html'],
+                    css: ['.css'],
+                    other: []
+                },
+                config_root: __dirname
+            };
+
+            const engine: Engine = await createEngineFromPlugin(defaultConfig);
+            const workspace: Workspace = new Workspace('test', [workspaceWithNonSSRLwc],
+                [path.join(workspaceWithNonSSRLwc, 'helloWorld.js')]);
+
+            // Act: Run the engine - the SSR rules are automatically enabled by LWC recommended config
+            const runOptions: RunOptions = createRunOptions(workspace);
+            // Run all rules to trigger SSR rules from the LWC recommended config
+            // Use empty array to run all configured rules
+            const results: EngineRunResults = await engine.runRules([], runOptions);
+
+            // Assert: Non-SSR component should NOT have SSR rule violations
+            // The SSR processor should filter out SSR rules for non-SSR components
+            expect(results.violations).toBeDefined();
+            const ssrViolations = results.violations.filter(v =>
+                v.ruleName && v.ruleName.includes('ssr-')
+            );
+            // Without the processor configured, this will fail because SSR rules will fire
+            // With the processor configured, SSR rules only fire on SSR-enabled components
+            expect(ssrViolations.length).toBe(0);
+        });
+
+        it('should parse files without errors when SSR processor is configured', async () => {
+            const defaultConfig: ConfigObject = {
+                file_extensions: {
+                    javascript: ['.js'],
+                    typescript: ['.ts'],
+                    html: ['.html'],
+                    css: ['.css'],
+                    other: []
+                },
+                config_root: __dirname
+            };
+
+            const engine: Engine = await createEngineFromPlugin(defaultConfig);
+            const workspace: Workspace = new Workspace('test', [workspaceWithNonSSRLwc],
+                [path.join(workspaceWithNonSSRLwc, 'helloWorld.js')]);
+
+            const runOptions: RunOptions = createRunOptions(workspace);
+            const results: EngineRunResults = await engine.runRules(['no-debugger'], runOptions);
+
+            // Assert: Should not have parsing errors
+            expect(results.violations).toBeDefined();
+            const parsingErrors = results.violations.filter(v =>
+                v.message.includes('Parsing error') || v.message.includes('Unexpected character')
+            );
+            expect(parsingErrors.length).toBe(0);
+        });
+    });
+});

--- a/packages/code-analyzer-eslint-engine/test/ssr-processor.test.ts
+++ b/packages/code-analyzer-eslint-engine/test/ssr-processor.test.ts
@@ -14,6 +14,28 @@ jest.setTimeout(60_000);
 
 const testDataFolder: string = path.join(__dirname, 'test-data');
 const workspaceWithNonSSRLwc: string = path.join(testDataFolder, 'workspaceWithNonSSRLwc');
+const workspaceWithSSRLwc: string = path.join(testDataFolder, 'workspaceWithSSRLwc');
+
+const SSR_RULE_NAMES: string[] = [
+    '@lwc/lwc/ssr-no-restricted-browser-globals',
+    '@lwc/lwc/ssr-no-node-env',
+];
+
+function createSSRConfigObject(): ConfigObject {
+    return {
+        // auto_discover_eslint_config picks up the eslint.config.js in each test workspace,
+        // which enables the SSR rules we want to assert against
+        auto_discover_eslint_config: true,
+        file_extensions: {
+            javascript: ['.js'],
+            typescript: ['.ts'],
+            html: ['.html'],
+            css: ['.css'],
+            other: []
+        },
+        config_root: __dirname
+    };
+}
 
 async function createEngineFromPlugin(configObject: ConfigObject): Promise<Engine> {
     const plugin: ESLintEnginePlugin = new ESLintEnginePlugin();
@@ -25,52 +47,41 @@ async function createEngineFromPlugin(configObject: ConfigObject): Promise<Engin
 describe('SSR Processor Configuration', () => {
     describe('Issue 2049: SSR rules should only apply to SSR-enabled components', () => {
         it('should not report SSR rule violations on non-SSR LWC components', async () => {
-            // Setup: Default config with LWC enabled
-            const defaultConfig: ConfigObject = {
-                file_extensions: {
-                    javascript: ['.js'],
-                    typescript: ['.ts'],
-                    html: ['.html'],
-                    css: ['.css'],
-                    other: []
-                },
-                config_root: __dirname
-            };
-
-            const engine: Engine = await createEngineFromPlugin(defaultConfig);
+            const engine: Engine = await createEngineFromPlugin(createSSRConfigObject());
             const workspace: Workspace = new Workspace('test', [workspaceWithNonSSRLwc],
                 [path.join(workspaceWithNonSSRLwc, 'helloWorld.js')]);
 
-            // Act: Run the engine - the SSR rules are automatically enabled by LWC recommended config
             const runOptions: RunOptions = createRunOptions(workspace);
-            // Run all rules to trigger SSR rules from the LWC recommended config
-            // Use empty array to run all configured rules
-            const results: EngineRunResults = await engine.runRules([], runOptions);
+            const results: EngineRunResults = await engine.runRules(SSR_RULE_NAMES, runOptions);
 
-            // Assert: Non-SSR component should NOT have SSR rule violations
             // The SSR processor should filter out SSR rules for non-SSR components
+            // (no lightning__ServerRenderable capability in -meta.xml)
             expect(results.violations).toBeDefined();
             const ssrViolations = results.violations.filter(v =>
                 v.ruleName && v.ruleName.includes('ssr-')
             );
-            // Without the processor configured, this will fail because SSR rules will fire
-            // With the processor configured, SSR rules only fire on SSR-enabled components
             expect(ssrViolations.length).toBe(0);
         });
 
-        it('should parse files without errors when SSR processor is configured', async () => {
-            const defaultConfig: ConfigObject = {
-                file_extensions: {
-                    javascript: ['.js'],
-                    typescript: ['.ts'],
-                    html: ['.html'],
-                    css: ['.css'],
-                    other: []
-                },
-                config_root: __dirname
-            };
+        it('should report SSR rule violations on SSR-enabled LWC components', async () => {
+            const engine: Engine = await createEngineFromPlugin(createSSRConfigObject());
+            const workspace: Workspace = new Workspace('test', [workspaceWithSSRLwc],
+                [path.join(workspaceWithSSRLwc, 'helloWorld.js')]);
 
-            const engine: Engine = await createEngineFromPlugin(defaultConfig);
+            // The SSR processor should create a virtual .ssrjs file for this component
+            // since its -meta.xml declares lightning__ServerRenderable capability
+            const runOptions: RunOptions = createRunOptions(workspace);
+            const results: EngineRunResults = await engine.runRules(SSR_RULE_NAMES, runOptions);
+
+            expect(results.violations).toBeDefined();
+            const ssrViolations = results.violations.filter(v =>
+                v.ruleName && v.ruleName.includes('ssr-')
+            );
+            expect(ssrViolations.length).toBeGreaterThan(0);
+        });
+
+        it('should parse files without errors when SSR processor is configured', async () => {
+            const engine: Engine = await createEngineFromPlugin(createSSRConfigObject());
             const workspace: Workspace = new Workspace('test', [workspaceWithNonSSRLwc],
                 [path.join(workspaceWithNonSSRLwc, 'helloWorld.js')]);
 

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/eslint.config.js
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/eslint.config.js
@@ -1,0 +1,18 @@
+const eslintPluginLwc = require('@lwc/eslint-plugin-lwc');
+
+// SSR rules are scoped to .ssrjs virtual files. The @lwc/lwc/ssr processor
+// (configured by the engine's base config) creates a virtual .ssrjs sibling
+// only for components whose -meta.xml declares SSR capabilities — so this
+// rule block fires only on SSR-enabled components.
+module.exports = [
+    {
+        files: ['**/*.ssrjs'],
+        plugins: {
+            '@lwc/lwc': eslintPluginLwc,
+        },
+        rules: {
+            '@lwc/lwc/ssr-no-restricted-browser-globals': 'error',
+            '@lwc/lwc/ssr-no-node-env': 'error',
+        },
+    },
+];

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/helloWorld.js
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/helloWorld.js
@@ -1,0 +1,11 @@
+import { LightningElement } from 'lwc';
+
+export default class HelloWorld extends LightningElement {
+    connectedCallback() {
+        // This code would violate SSR rules if SSR processor wasn't configured
+        console.log(window.location); // ssr-no-restricted-browser-globals
+        if (process.env.NODE_ENV === 'development') { // ssr-no-node-env
+            console.log('Development mode');
+        }
+    }
+}

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/helloWorld.js-meta.xml
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/helloWorld.js-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+    </targets>
+</LightningComponentBundle>

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithSSRLwc/eslint.config.js
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithSSRLwc/eslint.config.js
@@ -1,0 +1,18 @@
+const eslintPluginLwc = require('@lwc/eslint-plugin-lwc');
+
+// SSR rules are scoped to .ssrjs virtual files. The @lwc/lwc/ssr processor
+// (configured by the engine's base config) creates a virtual .ssrjs sibling
+// only for components whose -meta.xml declares SSR capabilities — so this
+// rule block fires only on SSR-enabled components.
+module.exports = [
+    {
+        files: ['**/*.ssrjs'],
+        plugins: {
+            '@lwc/lwc': eslintPluginLwc,
+        },
+        rules: {
+            '@lwc/lwc/ssr-no-restricted-browser-globals': 'error',
+            '@lwc/lwc/ssr-no-node-env': 'error',
+        },
+    },
+];

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithSSRLwc/helloWorld.js
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithSSRLwc/helloWorld.js
@@ -1,0 +1,12 @@
+import { LightningElement } from 'lwc';
+
+export default class HelloWorld extends LightningElement {
+    connectedCallback() {
+        // This code violates SSR rules and should be flagged because the
+        // -meta.xml declares lightning__ServerRenderable capability
+        console.log(window.location); // ssr-no-restricted-browser-globals
+        if (process.env.NODE_ENV === 'development') { // ssr-no-node-env
+            console.log('Development mode');
+        }
+    }
+}

--- a/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithSSRLwc/helloWorld.js-meta.xml
+++ b/packages/code-analyzer-eslint-engine/test/test-data/workspaceWithSSRLwc/helloWorld.js-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+    </targets>
+    <capabilities>
+        <capability>lightning__ServerRenderable</capability>
+    </capabilities>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
Fixes forcedotcom/code-analyzer#2049

## Root Cause
The SSR ESLint rules from @lwc/eslint-plugin-lwc are being applied to all LWC components instead of only SSR-enabled components. The root cause is that Code Analyzer's base-config.ts uses the LWC recommended configuration which includes SSR rules, but does not configure the SSR processor. The SSR processor (available at @lwc/eslint-plugin-lwc/processors/ssr) is designed to check each component's -meta.xml file for lightning__ServerRenderable or lightning__ServerRenderableWithHydration capabilities and only create virtual .ssrjs files for SSR components. Without the processor, SSR rules run on ALL LWC files regardless of their SSR capabilities.

## Fix
Added SSR processor configuration to base-config.ts to prevent false positives on non-SSR LWC components. The fix requires adding processor: '@lwc/lwc/ssr' to the LWC configuration in base-config.ts createJavascriptPlusLwcConfigArray() and createLwcConfigArray() methods.

## Testing
- ✅ Unit tests added/updated
- ✅ All tests passing
- ✅ Lint checks passing

## Functional Testing Evidence
Tested on Dreamhouse project:

**Test 1:** Non-SSR component with @salesforce/customPermission import
- PASS (no SSR violations, only class-methods-use-this warning)

**Test 2:** SSR component with lightning__ServerRenderable
- PASS (no violations)

Overall Status: PASS ✅

## Files Changed
- packages/code-analyzer-eslint-engine/src/base-config.ts
- packages/code-analyzer-eslint-engine/test/ssr-processor.test.ts
- packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/helloWorld.js
- packages/code-analyzer-eslint-engine/test/test-data/workspaceWithNonSSRLwc/helloWorld.js-meta.xml
- packages/code-analyzer-eslint-engine/package.json