### PR TITLE
CHANGE @W-22462041@ - Upgrade PMD from 7.24.0 to 7.25.0

### DIFF
--- a/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
+++ b/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
@@ -7,13 +7,13 @@
 
 [versions]
 hamcrest = "3.0"
-junit-jupiter = "5.14.3"
-pmd = "7.24.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
+junit-jupiter = "5.14.4"
+pmd = "7.25.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
 
 # For the following: Keep in sync with whatever pmd-core pulls in. Basically, we don't want duplicates in our java-lib folder.
 # To see pmd-core's dependencies, go to https://mvnrepository.com/artifact/net.sourceforge.pmd/pmd-core
 slf4j-nop = "1.7.36" # (Keep in sync with pmd-core > slf4j-api version). For now, we throw slf4j logs away (using this no-op module). We might use an actual logger in the future.
-gson = "2.13.2" # (Keep in sync with pmd-core > gson version).
+gson = "2.14.0" # (Keep in sync with pmd-core > gson version).
 
 
 [libraries]

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-pmd-engine",
   "description": "Plugin package that adds 'pmd' and 'cpd' as engines into Salesforce Code Analyzer",
-  "version": "0.42.0-SNAPSHOT",
+  "version": "0.43.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-pmd-engine/src/constants.ts
+++ b/packages/code-analyzer-pmd-engine/src/constants.ts
@@ -1,5 +1,5 @@
 // !!! IMPORTANT !!! KEEP THIS IN SYNC WITH gradle/libs.versions.toml
-export const PMD_VERSION: string = '7.24.0';
+export const PMD_VERSION: string = '7.25.0';
 
 export const PMD_ENGINE_NAME: string = "pmd";
 export const CPD_ENGINE_NAME: string = "cpd";


### PR DESCRIPTION
## Summary
Upgrades the bundled PMD engine from 7.24.0 to 7.25.0 for the monthly release.

## Changes
- **PMD**: 7.24.0 → 7.25.0 (`gradle/libs.versions.toml`, `src/constants.ts`)
- **junit-jupiter**: 5.14.3 → 5.14.4 (latest stable patch)
- **gson**: 2.13.2 → 2.14.0 (stays in sync with `pmd-core` 7.25.0's transitive `gson` dep)
- **@salesforce/code-analyzer-pmd-engine** package version: 0.42.0-SNAPSHOT → 0.43.0-SNAPSHOT

## Verification
- ✅ Clean Gradle build (only `pmd-*-7.25.0.jar` in `dist/java-lib`; no duplicate slf4j or gson)
- ✅ All Java tests pass
- ✅ All 127 TypeScript tests pass (98.84% coverage)

## PMD scan comparison (7.24.0 vs 7.25.0)
Ran the full comparison tool across **435 repos**:
- Total comparisons: **486,214**
- Mismatches: **0**
- Violation count delta: **0**
- Rule additions / removals / count changes: **0**
- Runtime: 22.0 min (7.24) vs 21.9 min (7.25) — essentially identical

PMD 7.25.0 is a behavior-preserving upgrade for our rule set. Full report archived to the team Drive.

## Test plan
- [x] Gradle clean build
- [x] Java unit tests
- [x] TypeScript unit tests
- [x] Full PMD comparison scan (435 repos, 0 mismatches)