### PR TITLE
CHANGE @W-22462048@ Upgrade PMD from 7.25.0 to 7.26.0

### DIFF
--- a/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
+++ b/packages/code-analyzer-pmd-engine/gradle/libs.versions.toml
@@ -8,7 +8,7 @@
 [versions]
 hamcrest = "3.0"
 junit-jupiter = "5.14.4"
-pmd = "7.25.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
+pmd = "7.26.0" # !!! IMPORTANT !!! KEEP THIS IN SYNC WITH PMD_VERSION INSIDE OF: src/constants.ts
 
 # For the following: Keep in sync with whatever pmd-core pulls in. Basically, we don't want duplicates in our java-lib folder.
 # To see pmd-core's dependencies, go to https://mvnrepository.com/artifact/net.sourceforge.pmd/pmd-core

--- a/packages/code-analyzer-pmd-engine/package.json
+++ b/packages/code-analyzer-pmd-engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/code-analyzer-pmd-engine",
   "description": "Plugin package that adds 'pmd' and 'cpd' as engines into Salesforce Code Analyzer",
-  "version": "0.43.0",
+  "version": "0.44.0-SNAPSHOT",
   "author": "The Salesforce Code Analyzer Team",
   "license": "BSD-3-Clause",
   "homepage": "https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/overview",

--- a/packages/code-analyzer-pmd-engine/src/constants.ts
+++ b/packages/code-analyzer-pmd-engine/src/constants.ts
@@ -1,5 +1,5 @@
 // !!! IMPORTANT !!! KEEP THIS IN SYNC WITH gradle/libs.versions.toml
-export const PMD_VERSION: string = '7.25.0';
+export const PMD_VERSION: string = '7.26.0';
 
 export const PMD_ENGINE_NAME: string = "pmd";
 export const CPD_ENGINE_NAME: string = "cpd";

--- a/packages/code-analyzer-pmd-engine/src/pmd-rule-mappings.ts
+++ b/packages/code-analyzer-pmd-engine/src/pmd-rule-mappings.ts
@@ -216,6 +216,10 @@ export const RULE_MAPPINGS: Record<string, {severity: SeverityLevel, tags: strin
         severity: SeverityLevel.Moderate,
         tags: [COMMON_TAGS.RECOMMENDED, COMMON_TAGS.CATEGORIES.ERROR_PRONE,    COMMON_TAGS.LANGUAGES.APEX]
     },
+    "InvocableClassNoArgConstructor": {
+        severity: SeverityLevel.Moderate,
+        tags: [COMMON_TAGS.RECOMMENDED, COMMON_TAGS.CATEGORIES.ERROR_PRONE,    COMMON_TAGS.LANGUAGES.APEX]
+    },
     "LocalVariableNamingConventions": {
         severity: SeverityLevel.Moderate,
         tags: [COMMON_TAGS.RECOMMENDED, COMMON_TAGS.CATEGORIES.CODE_STYLE,     COMMON_TAGS.LANGUAGES.APEX]

--- a/packages/code-analyzer-pmd-engine/test/test-data/pmdGoldfiles/rules_apexOnly.goldfile.json
+++ b/packages/code-analyzer-pmd-engine/test/test-data/pmdGoldfiles/rules_apexOnly.goldfile.json
@@ -817,6 +817,19 @@
     ]
   },
   {
+    "name": "InvocableClassNoArgConstructor",
+    "severityLevel": 3,
+    "tags": [
+      "Recommended",
+      "ErrorProne",
+      "Apex"
+    ],
+    "description": "Apex classes containing @InvocableVariable properties used for flow parameters must expose a visible, zero-argument constructor to prevent runtime instantiation errors under modern Salesforce API versions.",
+    "resourceUrls": [
+      "https://docs.pmd-code.org/pmd-doc-{{PMD_VERSION}}/pmd_rules_apex_errorprone.html#invocableclassnoargconstructor"
+    ]
+  },
+  {
     "name": "LocalVariableNamingConventions",
     "severityLevel": 3,
     "tags": [


### PR DESCRIPTION
## What & Why

Upgrades the PMD engine from **7.25.0** to **7.26.0** as part of the monthly release (@W-22462048@).

## Changes

- **PMD version** bumped to `7.26.0` in `gradle/libs.versions.toml` and `src/constants.ts` (kept in sync).
- **Package version** `code-analyzer-pmd-engine` bumped `0.43.0` → `0.44.0-SNAPSHOT`.
- **New Apex rule** `InvocableClassNoArgConstructor` (added in PMD 7.26.0) added to `RULE_MAPPINGS`:
  - Severity **Moderate**, tags **Recommended / ErrorProne / Apex** — matching the treatment of the previously-added Apex ErrorProne rule (`AvoidInterfaceAsMapKey`, #463).
  - Corresponding entry added to `test/test-data/pmdGoldfiles/rules_apexOnly.goldfile.json` (description sourced directly from the built engine).
- **Java dependencies** (hamcrest, junit-jupiter, slf4j-nop, gson) verified against PMD 7.26.0 core — no changes required (slf4j/gson still match pmd-core's transitive versions; junit-jupiter/hamcrest intentionally held to keep this PR scoped to the PMD upgrade).

## Validation

- ✅ Java build `BUILD SUCCESSFUL`; clean rebuild of `dist/java-lib` confirms only `pmd-*-7.26.0.jar` present (no stale 7.25.0 jars).
- ✅ TypeScript tests **127/127 passing**, coverage thresholds met.
- ✅ Lint clean; pre-commit interdependency validation passed.

## PMD Version Comparison (Step 1.2)

⏳ **In progress** — full scan comparison (`pmd_7_25` vs `pmd_7_26`) running across the local repo corpus (435 repos, github.com). Results will be reviewed and attached before merge.

> 🚦 **Do not merge** until the comparison results are reviewed and confirmed (only expected diff: new `InvocableClassNoArgConstructor` findings).
